### PR TITLE
chore: Adds a text component 

### DIFF
--- a/src/renderer/Theme.ts
+++ b/src/renderer/Theme.ts
@@ -29,6 +29,7 @@ const theme = createTheme({
     button: {
       fontSize: '1rem',
       fontWeight: 700,
+      textTransform: 'none',
     },
     caption: {
       fontSize: '0.75rem',

--- a/src/renderer/colors.ts
+++ b/src/renderer/colors.ts
@@ -7,3 +7,4 @@ export const DARK_ORANGE = '#E86826'
 
 export const GREEN = '#59A553'
 export const RED = '#D92222'
+export const BLACK = '#000000'

--- a/src/renderer/components/Text.tsx
+++ b/src/renderer/components/Text.tsx
@@ -10,17 +10,6 @@ const kindToVariant: { [k in Kind]: Variant } = {
   body: 'body1',
 } as const
 
-const getTextStyles = (
-  underline?: boolean,
-  bold?: boolean,
-  italic?: boolean,
-  style?: CSSProperties,
-) => ({
-  textDecoration: underline ? 'underline' : style?.textDecoration,
-  fontWeight: bold ? 'bold' : style?.fontWeight,
-  fontStyle: italic ? 'italic' : style?.fontStyle,
-})
-
 type BaseProps = PropsWithChildren<{
   align?: Extract<
     CSSProperties['textAlign'],
@@ -46,14 +35,14 @@ export function Text({
   underline,
   ...otherProps
 }: TextProps) {
-  const textStyles = getTextStyles(underline, bold, italic, style)
-
   return (
     <Typography
       variant={kindToVariant[kind]}
+      fontWeight={bold ? 'bold' : undefined}
+      fontStyle={italic ? 'italic' : undefined}
       style={{
         ...style,
-        ...textStyles,
+        textDecoration: underline ? 'underline' : undefined,
       }}
       {...otherProps}
     />

--- a/src/renderer/components/Text.tsx
+++ b/src/renderer/components/Text.tsx
@@ -1,4 +1,3 @@
-// Text.tsx
 import * as React from 'react'
 import { PropsWithChildren } from 'react'
 import Typography, { TypographyProps } from '@mui/material/Typography'

--- a/src/renderer/components/Text.tsx
+++ b/src/renderer/components/Text.tsx
@@ -1,0 +1,78 @@
+// Text.tsx
+import * as React from 'react'
+import { PropsWithChildren } from 'react'
+import Typography, { TypographyProps } from '@mui/material/Typography'
+
+type BaseProps = PropsWithChildren &
+  TypographyProps & { style?: React.CSSProperties }
+
+export function TitleText({ children, style, ...otherProps }: BaseProps) {
+  return (
+    <Typography variant="h1" style={style} {...otherProps}>
+      {children}
+    </Typography>
+  )
+}
+
+export function BodyText({ children, style, ...otherProps }: BaseProps) {
+  return (
+    <Typography variant="body1" style={style} {...otherProps}>
+      {children}
+    </Typography>
+  )
+}
+
+export function DescriptionText({ children, style, ...otherProps }: BaseProps) {
+  return (
+    <Typography variant="body2" style={style} {...otherProps}>
+      {children}
+    </Typography>
+  )
+}
+
+export function SubtitleText({ children, style, ...otherProps }: BaseProps) {
+  return (
+    <Typography variant="subtitle1" style={style} {...otherProps}>
+      {children}
+    </Typography>
+  )
+}
+
+type TextProps = BaseProps & {
+  kind?: 'title' | 'body' | 'description' | 'subtitle'
+}
+
+export function Text({ children, kind, style, ...otherProps }: TextProps) {
+  switch (kind) {
+    case 'title':
+      return (
+        <TitleText style={style} {...otherProps}>
+          {children}
+        </TitleText>
+      )
+    case 'body':
+      return (
+        <BodyText style={style} {...otherProps}>
+          {children}
+        </BodyText>
+      )
+    case 'description':
+      return (
+        <DescriptionText style={style} {...otherProps}>
+          {children}
+        </DescriptionText>
+      )
+    case 'subtitle':
+      return (
+        <SubtitleText style={style} {...otherProps}>
+          {children}
+        </SubtitleText>
+      )
+    default:
+      return (
+        <Typography style={style} {...otherProps}>
+          {children}
+        </Typography>
+      )
+  }
+}

--- a/src/renderer/components/Text.tsx
+++ b/src/renderer/components/Text.tsx
@@ -1,5 +1,25 @@
 import { CSSProperties, PropsWithChildren } from 'react'
+import { type Variant } from '@mui/material/styles/createTypography'
 import Typography from '@mui/material/Typography'
+
+type Kind = 'title' | 'subtitle' | 'body'
+
+const kindToVariant: { [k in Kind]: Variant } = {
+  title: 'h1',
+  subtitle: 'subtitle1',
+  body: 'body1',
+} as const
+
+const getTextStyles = (
+  underline?: boolean,
+  bold?: boolean,
+  italic?: boolean,
+  style?: CSSProperties,
+) => ({
+  textDecoration: underline ? 'underline' : style?.textDecoration,
+  fontWeight: bold ? 'bold' : style?.fontWeight,
+  fontStyle: italic ? 'italic' : style?.fontStyle,
+})
 
 type BaseProps = PropsWithChildren<{
   align?: Extract<
@@ -11,117 +31,31 @@ type BaseProps = PropsWithChildren<{
   id?: string
   italic?: boolean
   style?: CSSProperties
-  underlined?: boolean
+  underline?: boolean
 }>
 
-export function TitleText({
-  align,
-  bold,
-  children,
-  className,
-  italic,
-  style,
-  underlined,
-}: BaseProps) {
-  return (
-    <Typography
-      variant="h1"
-      align={align}
-      style={{
-        ...style,
-        fontWeight: bold ? 'bold' : undefined,
-        fontStyle: italic ? 'italic' : undefined,
-        textDecoration: underlined ? 'underline' : undefined,
-      }}
-      className={className}
-    >
-      {children}
-    </Typography>
-  )
-}
-
-export function BodyText({
-  align,
-  bold,
-  children,
-  className,
-  italic,
-  style,
-  underlined,
-}: BaseProps) {
-  return (
-    <Typography
-      variant="body1"
-      style={{
-        ...style,
-        fontWeight: bold ? 'bold' : undefined,
-        fontStyle: italic ? 'italic' : undefined,
-        textDecoration: underlined ? 'underline' : undefined,
-      }}
-      align={align}
-      className={className}
-    >
-      {children}
-    </Typography>
-  )
-}
-
-export function SubtitleText({
-  align,
-  bold,
-  children,
-  className,
-  italic,
-  style,
-  underlined,
-}: BaseProps) {
-  return (
-    <Typography
-      variant="subtitle1"
-      style={{
-        ...style,
-        fontWeight: bold ? 'bold' : undefined,
-        fontStyle: italic ? 'italic' : undefined,
-        textDecoration: underlined ? 'underline' : undefined,
-      }}
-      align={align}
-      className={className}
-    >
-      {children}
-    </Typography>
-  )
-}
-
 type TextProps = BaseProps & {
-  kind?: 'title' | 'body' | 'subtitle'
+  kind?: Kind
 }
 
 export function Text({
-  children,
+  bold,
+  italic,
   kind = 'body',
   style,
+  underline,
   ...otherProps
 }: TextProps) {
-  switch (kind) {
-    case 'title':
-      return (
-        <TitleText style={style} {...otherProps}>
-          {children}
-        </TitleText>
-      )
-    case 'body':
-      return (
-        <BodyText style={style} {...otherProps}>
-          {children}
-        </BodyText>
-      )
-    case 'subtitle':
-      return (
-        <SubtitleText style={style} {...otherProps}>
-          {children}
-        </SubtitleText>
-      )
-    default:
-      throw new Error(`Invalid 'kind' prop value: ${kind}`)
-  }
+  const textStyles = getTextStyles(underline, bold, italic, style)
+
+  return (
+    <Typography
+      variant={kindToVariant[kind]}
+      style={{
+        ...style,
+        ...textStyles,
+      }}
+      {...otherProps}
+    />
+  )
 }

--- a/src/renderer/components/Text.tsx
+++ b/src/renderer/components/Text.tsx
@@ -93,10 +93,15 @@ export function SubtitleText({
 }
 
 type TextProps = BaseProps & {
-  kind: 'title' | 'body' | 'subtitle'
+  kind?: 'title' | 'body' | 'subtitle'
 }
 
-export function Text({ children, kind, style, ...otherProps }: TextProps) {
+export function Text({
+  children,
+  kind = 'body',
+  style,
+  ...otherProps
+}: TextProps) {
   switch (kind) {
     case 'title':
       return (

--- a/src/renderer/components/Text.tsx
+++ b/src/renderer/components/Text.tsx
@@ -41,8 +41,8 @@ export function Text({
       fontWeight={bold ? 'bold' : undefined}
       fontStyle={italic ? 'italic' : undefined}
       style={{
-        ...style,
         textDecoration: underline ? 'underline' : undefined,
+        ...style,
       }}
       {...otherProps}
     />

--- a/src/renderer/components/Text.tsx
+++ b/src/renderer/components/Text.tsx
@@ -1,44 +1,99 @@
-import * as React from 'react'
-import { PropsWithChildren } from 'react'
-import Typography, { TypographyProps } from '@mui/material/Typography'
+import { CSSProperties, PropsWithChildren } from 'react'
+import Typography from '@mui/material/Typography'
 
-type BaseProps = PropsWithChildren &
-  TypographyProps & { style?: React.CSSProperties }
+type BaseProps = PropsWithChildren<{
+  align?: Extract<
+    CSSProperties['textAlign'],
+    'inherit' | 'left' | 'center' | 'right' | 'justify'
+  >
+  bold?: boolean
+  className?: string
+  id?: string
+  italic?: boolean
+  style?: CSSProperties
+  underlined?: boolean
+}>
 
-export function TitleText({ children, style, ...otherProps }: BaseProps) {
+export function TitleText({
+  align,
+  bold,
+  children,
+  className,
+  italic,
+  style,
+  underlined,
+}: BaseProps) {
   return (
-    <Typography variant="h1" style={style} {...otherProps}>
+    <Typography
+      variant="h1"
+      align={align}
+      style={{
+        ...style,
+        fontWeight: bold ? 'bold' : undefined,
+        fontStyle: italic ? 'italic' : undefined,
+        textDecoration: underlined ? 'underline' : undefined,
+      }}
+      className={className}
+    >
       {children}
     </Typography>
   )
 }
 
-export function BodyText({ children, style, ...otherProps }: BaseProps) {
+export function BodyText({
+  align,
+  bold,
+  children,
+  className,
+  italic,
+  style,
+  underlined,
+}: BaseProps) {
   return (
-    <Typography variant="body1" style={style} {...otherProps}>
+    <Typography
+      variant="body1"
+      style={{
+        ...style,
+        fontWeight: bold ? 'bold' : undefined,
+        fontStyle: italic ? 'italic' : undefined,
+        textDecoration: underlined ? 'underline' : undefined,
+      }}
+      align={align}
+      className={className}
+    >
       {children}
     </Typography>
   )
 }
 
-export function DescriptionText({ children, style, ...otherProps }: BaseProps) {
+export function SubtitleText({
+  align,
+  bold,
+  children,
+  className,
+  italic,
+  style,
+  underlined,
+}: BaseProps) {
   return (
-    <Typography variant="body2" style={style} {...otherProps}>
-      {children}
-    </Typography>
-  )
-}
-
-export function SubtitleText({ children, style, ...otherProps }: BaseProps) {
-  return (
-    <Typography variant="subtitle1" style={style} {...otherProps}>
+    <Typography
+      variant="subtitle1"
+      style={{
+        ...style,
+        fontWeight: bold ? 'bold' : undefined,
+        fontStyle: italic ? 'italic' : undefined,
+        textDecoration: underlined ? 'underline' : undefined,
+      }}
+      align={align}
+      className={className}
+    >
       {children}
     </Typography>
   )
 }
 
 type TextProps = BaseProps & {
-  kind?: 'title' | 'body' | 'description' | 'subtitle'
+  kind: 'title' | 'body' | 'subtitle'
 }
 
 export function Text({ children, kind, style, ...otherProps }: TextProps) {
@@ -55,12 +110,6 @@ export function Text({ children, kind, style, ...otherProps }: TextProps) {
           {children}
         </BodyText>
       )
-    case 'description':
-      return (
-        <DescriptionText style={style} {...otherProps}>
-          {children}
-        </DescriptionText>
-      )
     case 'subtitle':
       return (
         <SubtitleText style={style} {...otherProps}>
@@ -68,10 +117,6 @@ export function Text({ children, kind, style, ...otherProps }: TextProps) {
         </SubtitleText>
       )
     default:
-      return (
-        <Typography style={style} {...otherProps}>
-          {children}
-        </Typography>
-      )
+      throw new Error(`Invalid 'kind' prop value: ${kind}`)
   }
 }

--- a/src/renderer/pages/Home.tsx
+++ b/src/renderer/pages/Home.tsx
@@ -22,16 +22,14 @@ export function Home() {
   const createProjectMutation = useCreateProject()
 
   if (allProjectsQuery.status === 'pending')
-    return <Text variant="button">Loading...</Text>
+    return <Text kind="body">Loading...</Text>
   if (allProjectsQuery.status === 'error')
-    return <Text variant="button">Error: {allProjectsQuery.error.message}</Text>
+    return <Text kind="body">Error: {allProjectsQuery.error.message}</Text>
 
   return (
     <div>
-      <Text kind="title" gutterBottom>
-        CoMapeo Desktop
-      </Text>
-      <Text kind="subtitle" color="tomato" style={{ margin: 10 }}>
+      <Text kind="title">CoMapeo Desktop</Text>
+      <Text kind="subtitle" style={{ margin: 10 }}>
         An Awana Digital Product
       </Text>
       <Grid container alignItems="center" spacing={2} wrap="nowrap">
@@ -47,17 +45,17 @@ export function Home() {
         </Grid>
         <Grid item>
           <Button variant="outlined" color="secondary">
-            <Text variant="button">An Outlined Button!</Text>
+            An Outlined Button!
           </Button>
         </Grid>
         <Grid item>
           <Button variant="text" color="success">
-            <Text variant="button">A Text Button!</Text>
+            A Typography Button!
           </Button>
         </Grid>
         <Grid item>
           <Button sx={{ backgroundColor: theme.palette.primary.dark }}>
-            <Text variant="button">Style override</Text>
+            Style override
           </Button>
         </Grid>
       </Grid>
@@ -70,7 +68,7 @@ export function Home() {
               variant="contained"
               onClick={() => alert('Full Width Button Clicked')}
             >
-              <Text variant="button">Full Width Button</Text>
+              Full Width Button
             </Button>
           </Grid>
         </Grid>

--- a/src/renderer/pages/Home.tsx
+++ b/src/renderer/pages/Home.tsx
@@ -31,10 +31,7 @@ export function Home() {
       <Text kind="title" gutterBottom>
         CoMapeo Desktop
       </Text>
-      <Text
-        kind="subtitle"
-        style={{ color: 'tomato', marginTop: 3, marginBottom: 3 }}
-      >
+      <Text kind="subtitle" color="tomato" style={{ margin: 10 }}>
         An Awana Digital Product
       </Text>
       <Grid container alignItems="center" spacing={2} wrap="nowrap">

--- a/src/renderer/pages/Home.tsx
+++ b/src/renderer/pages/Home.tsx
@@ -30,11 +30,7 @@ export function Home() {
       <Text kind="title" italic>
         CoMapeo Desktop
       </Text>
-      <Text
-        kind="subtitle"
-        style={{ margin: 10, textDecoration: 'underline' }}
-        bold
-      >
+      <Text kind="subtitle" style={{ margin: 10 }} underline>
         An Awana Digital Product
       </Text>
       <Grid container alignItems="center" spacing={2} wrap="nowrap">
@@ -82,9 +78,7 @@ export function Home() {
         <ul>
           {allProjectsQuery.data.map((project) => (
             <li key={project.projectId}>
-              <Text style={{ fontStyle: 'italic' }} bold>
-                {project.name || 'No name'}
-              </Text>
+              <Text bold>{project.name || 'No name'}</Text>
             </li>
           ))}
         </ul>

--- a/src/renderer/pages/Home.tsx
+++ b/src/renderer/pages/Home.tsx
@@ -21,10 +21,9 @@ export function Home() {
   const allProjectsQuery = useAllProjects()
   const createProjectMutation = useCreateProject()
 
-  if (allProjectsQuery.status === 'pending')
-    return <Text kind="body">Loading...</Text>
+  if (allProjectsQuery.status === 'pending') return <Text>Loading...</Text>
   if (allProjectsQuery.status === 'error')
-    return <Text kind="body">Error: {allProjectsQuery.error.message}</Text>
+    return <Text>Error: {allProjectsQuery.error.message}</Text>
 
   return (
     <div>
@@ -77,7 +76,7 @@ export function Home() {
         <ul>
           {allProjectsQuery.data.map((project) => (
             <li key={project.projectId}>
-              <Text kind="body">{project.name || 'No name'}</Text>
+              <Text>{project.name || 'No name'}</Text>
             </li>
           ))}
         </ul>

--- a/src/renderer/pages/Home.tsx
+++ b/src/renderer/pages/Home.tsx
@@ -2,7 +2,7 @@ import { Box, Grid, useTheme } from '@mui/material'
 import { defineMessages, FormattedMessage } from 'react-intl'
 
 import { Button } from '../components/Button'
-import { Text } from '../components/Text.tsx'
+import { Text } from '../components/Text'
 import { useAllProjects, useCreateProject } from '../queries/projects'
 
 const m = defineMessages({
@@ -27,8 +27,14 @@ export function Home() {
 
   return (
     <div>
-      <Text kind="title">CoMapeo Desktop</Text>
-      <Text kind="subtitle" style={{ margin: 10 }}>
+      <Text kind="title" italic>
+        CoMapeo Desktop
+      </Text>
+      <Text
+        kind="subtitle"
+        style={{ margin: 10, textDecoration: 'underline' }}
+        bold
+      >
         An Awana Digital Product
       </Text>
       <Grid container alignItems="center" spacing={2} wrap="nowrap">
@@ -76,7 +82,9 @@ export function Home() {
         <ul>
           {allProjectsQuery.data.map((project) => (
             <li key={project.projectId}>
-              <Text>{project.name || 'No name'}</Text>
+              <Text style={{ fontStyle: 'italic' }} bold>
+                {project.name || 'No name'}
+              </Text>
             </li>
           ))}
         </ul>

--- a/src/renderer/pages/Home.tsx
+++ b/src/renderer/pages/Home.tsx
@@ -1,7 +1,8 @@
-import { Box, Grid, Typography, useTheme } from '@mui/material'
+import { Box, Grid, useTheme } from '@mui/material'
 import { defineMessages, FormattedMessage } from 'react-intl'
 
-import { Button } from '../components/Button.tsx'
+import { Button } from '../components/Button'
+import { Text } from '../components/Text.tsx'
 import { useAllProjects, useCreateProject } from '../queries/projects'
 
 const m = defineMessages({
@@ -21,15 +22,21 @@ export function Home() {
   const createProjectMutation = useCreateProject()
 
   if (allProjectsQuery.status === 'pending')
-    return <Typography>Loading...</Typography>
+    return <Text variant="button">Loading...</Text>
   if (allProjectsQuery.status === 'error')
-    return <Typography>Error: {allProjectsQuery.error.message}</Typography>
+    return <Text variant="button">Error: {allProjectsQuery.error.message}</Text>
 
   return (
     <div>
-      <Typography variant="h1" gutterBottom>
+      <Text kind="title" gutterBottom>
         CoMapeo Desktop
-      </Typography>
+      </Text>
+      <Text
+        kind="subtitle"
+        style={{ color: 'tomato', marginTop: 3, marginBottom: 3 }}
+      >
+        An Awana Digital Product
+      </Text>
       <Grid container alignItems="center" spacing={2} wrap="nowrap">
         <Grid item>
           <Button
@@ -43,17 +50,17 @@ export function Home() {
         </Grid>
         <Grid item>
           <Button variant="outlined" color="secondary">
-            An Outlined Button!
+            <Text variant="button">An Outlined Button!</Text>
           </Button>
         </Grid>
         <Grid item>
           <Button variant="text" color="success">
-            A Text Button!
+            <Text variant="button">A Text Button!</Text>
           </Button>
         </Grid>
         <Grid item>
           <Button sx={{ backgroundColor: theme.palette.primary.dark }}>
-            Style override
+            <Text variant="button">Style override</Text>
           </Button>
         </Grid>
       </Grid>
@@ -66,7 +73,7 @@ export function Home() {
               variant="contained"
               onClick={() => alert('Full Width Button Clicked')}
             >
-              Full Width Button
+              <Text variant="button">Full Width Button</Text>
             </Button>
           </Grid>
         </Grid>
@@ -75,9 +82,7 @@ export function Home() {
         <ul>
           {allProjectsQuery.data.map((project) => (
             <li key={project.projectId}>
-              <Typography variant="body1">
-                {project.name || 'No name'}
-              </Typography>
+              <Text kind="body">{project.name || 'No name'}</Text>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
closes #17 
### Description
- Creates a shred Text component that accepts a prop kind, that returns either 'title' | 'body'  | 'subtitle'. If no kind if passed, it defaults to 'body'.
- accepts props for bold, italic, underline
- Can pass style to any of the text components but these will not override the bold, italic, underline

### Small fixes
- Adds no text transform to the button as specified in the design docs (https://www.notion.so/digidem/Typography-a1600603854445ad82b8d67d4067be1a)
- Adds black to colors


![Screenshot 2024-07-04 at 5 22 02 PM](https://github.com/digidem/comapeo-desktop/assets/20581639/1cc76d4a-4368-4693-8f72-ca3882f4683f)
