### PR TITLE
chore: use style instead of sx prop for Button

### DIFF
--- a/src/renderer/components/Button.tsx
+++ b/src/renderer/components/Button.tsx
@@ -1,8 +1,5 @@
-import { MouseEventHandler, PropsWithChildren } from 'react'
-import {
-  Button as MuiButton,
-  ButtonProps as MuiButtonProps,
-} from '@mui/material'
+import { CSSProperties, MouseEventHandler, PropsWithChildren } from 'react'
+import { Button as MuiButton } from '@mui/material'
 
 type CustomButtonProps = PropsWithChildren<{
   name?: string
@@ -11,7 +8,7 @@ type CustomButtonProps = PropsWithChildren<{
   size?: 'medium' | 'large' | 'fullWidth'
   testID?: string
   variant?: 'contained' | 'outlined' | 'text'
-  sx?: MuiButtonProps['sx']
+  style?: CSSProperties
   onClick?: MouseEventHandler<HTMLButtonElement>
 }>
 
@@ -21,6 +18,7 @@ export const Button = ({
   size = 'medium',
   color = 'primary',
   variant = 'contained',
+  style,
   ...props
 }: CustomButtonProps) => {
   const propsBasedOnSize = size === 'fullWidth' ? { fullWidth: true } : { size }
@@ -28,7 +26,7 @@ export const Button = ({
     <MuiButton
       color={color}
       variant={variant}
-      sx={props.sx}
+      style={style}
       data-testid={testID}
       {...propsBasedOnSize}
       onClick={props.onClick}

--- a/src/renderer/pages/Home.tsx
+++ b/src/renderer/pages/Home.tsx
@@ -52,7 +52,7 @@ export function Home() {
           </Button>
         </Grid>
         <Grid item>
-          <Button sx={{ backgroundColor: theme.palette.primary.dark }}>
+          <Button style={{ backgroundColor: theme.palette.primary.dark }}>
             Style override
           </Button>
         </Grid>


### PR DESCRIPTION
Mostly in response to what I wrote here: https://github.com/digidem/comapeo-desktop/pull/28#discussion_r1674442554, in case we prefer being less tied to MUI and want to unify the interface a bit across our custom components