### PR TITLE
implement ipc for file selection

### DIFF
--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -1,0 +1,29 @@
+import {
+	array,
+	object,
+	optional,
+	parse,
+	string,
+	undefined,
+	union,
+} from 'valibot'
+
+const FilesSelectParamsSchema = union([
+	object({
+		extensionFilters: optional(array(string())),
+	}),
+	undefined(),
+])
+
+export const APP_IPC_EVENT_TO_PARAMS_PARSER = /** @type {const} */ ({
+	/**
+	 * @param {unknown} value
+	 *
+	 * @returns {import('valibot').InferOutput<typeof FilesSelectParamsSchema>}
+	 */
+	'files:select': (value) => {
+		return parse(FilesSelectParamsSchema, value)
+	},
+})
+
+/** @typedef {keyof typeof APP_IPC_EVENT_TO_PARAMS_PARSER} AppIPCEvents */

--- a/src/preload/main-window.js
+++ b/src/preload/main-window.js
@@ -23,11 +23,26 @@ const runtimeApi = {
 	// Locale
 	async getLocale() {
 		const locale = await ipcRenderer.invoke('locale:get')
-		if (typeof locale !== 'string') throw Error('Locale must be a string')
+		if (typeof locale !== 'string') {
+			throw new Error('Locale must be a string')
+		}
 		return locale
 	},
 	updateLocale(locale) {
 		ipcRenderer.send('locale:update', locale)
+	},
+
+	// Files
+	async selectFile(extensionFilters) {
+		const filePath = await ipcRenderer.invoke('files:select', {
+			extensionFilters,
+		})
+
+		if (!(typeof filePath === 'string' || typeof filePath === 'undefined')) {
+			throw new Error(`File path is unexpected type: ${typeof filePath}`)
+		}
+
+		return filePath
 	},
 }
 

--- a/src/preload/runtime.d.ts
+++ b/src/preload/runtime.d.ts
@@ -2,4 +2,5 @@ export type RuntimeApi = {
 	init: () => void
 	getLocale: () => Promise<string>
 	updateLocale: (locale: string) => void
+	selectFile: (extensionFilters?: Array<string>) => Promise<string | undefined>
 }

--- a/src/renderer/src/hooks/mutations/file-system.ts
+++ b/src/renderer/src/hooks/mutations/file-system.ts
@@ -1,0 +1,13 @@
+import { useMutation } from '@tanstack/react-query'
+
+/**
+ * If the resolved value is `undefined` that means the user did not select a
+ * file (i.e. cancelled the selection dialog)
+ */
+export function useSelectProjectConfigFile() {
+	return useMutation({
+		mutationFn: async () => {
+			return window.runtime.selectFile(['comapeocat'])
+		},
+	})
+}


### PR DESCRIPTION
Related to #55

Sets up the mechanisms for initiating the selection of a file in the filesystem from the renderer side and retrieving the full path to the selected file. Having this will enable features such as importing a project config file or custom map file.

This PR introduces the following:

- IPC handler on the main window for summoning the open file dialog and returning the full path to the selected file (or `undefined` if no file is selected). Multi-file support was considered but we don't have an immediate need for it, so opted to refrain from including in this implementation.
- new renderer-available "runtime" method `selectFile(extensionFilters)` which sends the relevant IPC and waits for the result.
- mutation hook `useSelectProjectConfigFile()` which is unused in this PR, but will help #55. Example usage could look like the following:

    ```tsx
    onClick={() => {
	    selectConfigFile.mutate(undefined, {
		    onSuccess: (filePath) => {
			    if (filePath) {
				    // Do something with selected file...
			    } else {
				    // No file selected due to dialog cancellation
			    }
		    },
		    onError: (error) => {
			    // Handle error...
		    },
	    })
    }}
    ```