### PR TITLE
feat: update runtime.selectFile() to also return the file name

### DIFF
--- a/src/main/app.js
+++ b/src/main/app.js
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto'
+import { basename } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineMessages } from '@formatjs/intl'
 import debug from 'debug'
@@ -243,7 +244,14 @@ function initMainWindow({ appMode, services }) {
 				: undefined,
 		})
 
-		return result.filePaths[0]
+		const selectedFilePath = result.filePaths[0]
+
+		if (!selectedFilePath) return undefined
+
+		return {
+			name: basename(selectedFilePath),
+			path: selectedFilePath,
+		}
 	})
 
 	APP_STATE.browserWindows.set(mainWindow, {

--- a/src/preload/main-window.js
+++ b/src/preload/main-window.js
@@ -28,16 +28,36 @@ const runtimeApi = {
 
 	// Files
 	async selectFile(extensionFilters) {
-		const filePath = await ipcRenderer.invoke('files:select', {
+		/** @type {unknown} */
+		const result = await ipcRenderer.invoke('files:select', {
 			extensionFilters,
 		})
 
-		if (!(typeof filePath === 'string' || typeof filePath === 'undefined')) {
-			throw new Error(`File path is unexpected type: ${typeof filePath}`)
-		}
+		if (!result) return undefined
 
-		return filePath
+		validateSelectedFileResult(result)
+
+		return result
 	},
+}
+
+/**
+ * @param {NonNullable<unknown>} value
+ *
+ * @returns {asserts value is import('./runtime.js').SelectedFile}
+ */
+function validateSelectedFileResult(value) {
+	if (!('path' in value && 'name' in value)) {
+		throw new Error('Value has invalid shape')
+	}
+
+	if (typeof value.path !== 'string') {
+		throw new Error('Value has invalid path field')
+	}
+
+	if (typeof value.name !== 'string') {
+		throw new Error('Value has invalid name field')
+	}
 }
 
 contextBridge.exposeInMainWorld('runtime', runtimeApi)

--- a/src/preload/runtime.d.ts
+++ b/src/preload/runtime.d.ts
@@ -1,5 +1,12 @@
+export type SelectedFile = {
+	name: string
+	path: string
+}
+
 export type RuntimeApi = {
 	getLocale: () => Promise<string>
 	updateLocale: (locale: string) => void
-	selectFile: (extensionFilters?: Array<string>) => Promise<string | undefined>
+	selectFile: (
+		extensionFilters?: Array<string>,
+	) => Promise<SelectedFile | undefined>
 }


### PR DESCRIPTION
Updates `runtime.selectFile()` to return an object that contains the path and name of the selected file, as opposed to just the path. Informed by the needs of #55 