### PR TITLE
feat: implement device name settings page

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -12,9 +12,11 @@
     "message": "No Observations Found"
   },
   "lib.schemas.device-name.maxLengthError": {
+    "description": "Error message for device name that is too long.",
     "message": "Too long, try a shorter name."
   },
   "lib.schemas.device-name.minLengthError": {
+    "description": "Error message for device name that is too short.",
     "message": "Enter a Device Name"
   },
   "mapMain.errorLoading": {

--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -11,6 +11,12 @@
   "emptyState.noObservationsFound": {
     "message": "No Observations Found"
   },
+  "lib.schemas.device-name.maxLengthError": {
+    "message": "Too long, try a shorter name."
+  },
+  "lib.schemas.device-name.minLengthError": {
+    "message": "Enter a Device Name"
+  },
   "mapMain.errorLoading": {
     "message": "Oops! Error loading data."
   },
@@ -67,6 +73,26 @@
   },
   "routes.app.route.exchangeTabLabel": {
     "message": "Exchange"
+  },
+  "routes.app.settings.device-name.cancel": {
+    "description": "Label for cancel button.",
+    "message": "Cancel"
+  },
+  "routes.app.settings.device-name.characterCount": {
+    "description": "Displays number of characters in input out of the maximum allowed characters.",
+    "message": "{count}/{max}"
+  },
+  "routes.app.settings.device-name.inputLabel": {
+    "description": "Label for the device name input.",
+    "message": "Device Name"
+  },
+  "routes.app.settings.device-name.navTitle": {
+    "description": "Title of the device name settings page.",
+    "message": "Device Name"
+  },
+  "routes.app.settings.device-name.save": {
+    "description": "Label for save button.",
+    "message": "Save"
   },
   "routes.app.settings.index.decimalDegrees": {
     "description": "Label for Decimal Degrees coordinate system.",

--- a/src/renderer/src/lib/schemas/device-name.ts
+++ b/src/renderer/src/lib/schemas/device-name.ts
@@ -1,0 +1,39 @@
+import { defineMessages, type IntlShape } from 'react-intl'
+import * as v from 'valibot'
+
+import {
+	DEVICE_NAME_MAX_LENGTH_GRAPHEMES,
+	INPUT_NAME_MAX_BYTES,
+} from '../constants'
+
+export function createDeviceNameSchema({
+	formatMessage,
+}: {
+	formatMessage: IntlShape['formatMessage']
+}) {
+	return v.pipe(
+		v.string(),
+		v.transform((value) => {
+			return value.trim()
+		}),
+		v.minLength(1, formatMessage(m.minLengthError)),
+		v.maxGraphemes(
+			DEVICE_NAME_MAX_LENGTH_GRAPHEMES,
+			formatMessage(m.maxLengthError),
+		),
+		v.maxBytes(INPUT_NAME_MAX_BYTES, formatMessage(m.maxLengthError)),
+	)
+}
+
+const m = defineMessages({
+	minLengthError: {
+		id: 'lib.schemas.device-name.minLengthError',
+		defaultMessage: 'Enter a Device Name',
+		description: 'Error message for device name that is too short.',
+	},
+	maxLengthError: {
+		id: 'lib.schemas.device-name.maxLengthError',
+		defaultMessage: 'Too long, try a shorter name.',
+		description: 'Error message for device name that is too long.',
+	},
+})

--- a/src/renderer/src/routes/app/settings/device-name.tsx
+++ b/src/renderer/src/routes/app/settings/device-name.tsx
@@ -1,9 +1,245 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { useMemo } from 'react'
+import { useOwnDeviceInfo, useSetOwnDeviceInfo } from '@comapeo/core-react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { createFileRoute, useRouter } from '@tanstack/react-router'
+import { defineMessages, useIntl } from 'react-intl'
+import * as v from 'valibot'
+
+import { BLUE_GREY, WHITE } from '../../../colors'
+import { Icon } from '../../../components/icon'
+import { useAppForm } from '../../../hooks/use-app-form'
+import { DEVICE_NAME_MAX_LENGTH_GRAPHEMES } from '../../../lib/constants'
+import { createDeviceNameSchema } from '../../../lib/schemas/device-name'
 
 export const Route = createFileRoute('/app/settings/device-name')({
 	component: RouteComponent,
 })
 
+const FORM_ID = 'device-name-form'
+
 function RouteComponent() {
-	return <div>Hello "/app/settings/device-name"!</div>
+	const { formatMessage: t } = useIntl()
+	const router = useRouter()
+
+	const { data: deviceInfo } = useOwnDeviceInfo()
+	const setOwnDeviceInfo = useSetOwnDeviceInfo()
+
+	// TODO: We want to provide translated error messages that can be rendered directly
+	// Probably not ideal do this reactively but can address later
+	const deviceNameSchema = useMemo(() => {
+		return createDeviceNameSchema({ formatMessage: t })
+	}, [t])
+
+	const form = useAppForm({
+		defaultValues: {
+			deviceName: deviceInfo.name ? deviceInfo.name : '',
+		},
+		validators: {
+			onChange: v.object({ deviceName: deviceNameSchema }),
+		},
+		onSubmit: async ({ value }) => {
+			const parsedDeviceName = v.parse(deviceNameSchema, value.deviceName)
+
+			await setOwnDeviceInfo.mutateAsync({
+				deviceType: 'desktop',
+				name: parsedDeviceName,
+			})
+
+			router.navigate({ to: '/app/settings' })
+		},
+	})
+
+	return (
+		<>
+			<Stack direction="column" flex={1}>
+				<Stack
+					direction="row"
+					alignItems="center"
+					component="nav"
+					useFlexGap
+					gap={4}
+					padding={4}
+					borderBottom={`1px solid ${BLUE_GREY}`}
+				>
+					<IconButton
+						onClick={() => {
+							if (form.state.isSubmitting) {
+								return
+							}
+
+							if (router.history.canGoBack()) {
+								router.history.back()
+								return
+							}
+
+							router.navigate({ to: '/app/settings', replace: true })
+						}}
+					>
+						<Icon name="material-arrow-back" size={30} />
+					</IconButton>
+					<Typography variant="h1" fontWeight={500}>
+						{t(m.navTitle)}
+					</Typography>
+				</Stack>
+
+				<Stack
+					direction="column"
+					flex={1}
+					justifyContent="space-between"
+					overflow="auto"
+				>
+					<Box padding={6}>
+						<Box
+							component="form"
+							id={FORM_ID}
+							noValidate
+							autoComplete="off"
+							onSubmit={(event) => {
+								event.preventDefault()
+								if (form.state.isSubmitting) return
+								form.handleSubmit()
+							}}
+						>
+							<form.AppField name="deviceName">
+								{(field) => (
+									<field.TextField
+										required
+										fullWidth
+										label={t(m.inputLabel)}
+										value={field.state.value}
+										error={!field.state.meta.isValid}
+										onChange={(event) => {
+											field.handleChange(event.target.value)
+										}}
+										slotProps={{
+											input: {
+												style: {
+													backgroundColor: WHITE,
+												},
+											},
+										}}
+										onBlur={field.handleBlur}
+										helperText={
+											<Stack
+												component="span"
+												direction="row"
+												justifyContent="space-between"
+											>
+												<Box component="span">
+													{field.state.meta.errors[0]?.message}
+												</Box>
+												<Box component="span">
+													<form.Subscribe
+														selector={(state) =>
+															v._getGraphemeCount(state.values.deviceName)
+														}
+													>
+														{(count) =>
+															t(m.characterCount, {
+																count,
+																max: DEVICE_NAME_MAX_LENGTH_GRAPHEMES,
+															})
+														}
+													</form.Subscribe>
+												</Box>
+											</Stack>
+										}
+									/>
+								)}
+							</form.AppField>
+						</Box>
+					</Box>
+
+					<Stack
+						direction="column"
+						useFlexGap
+						gap={4}
+						paddingX={6}
+						paddingBottom={6}
+						position="sticky"
+						bottom={0}
+						alignItems="center"
+					>
+						<form.Subscribe
+							selector={(state) => [state.canSubmit, state.isSubmitting]}
+						>
+							{([canSubmit, isSubmitting]) => (
+								<>
+									<Button
+										type="button"
+										variant="outlined"
+										size="large"
+										fullWidth
+										disableElevation
+										aria-disabled={isSubmitting}
+										onClick={() => {
+											if (isSubmitting) return
+
+											if (router.history.canGoBack()) {
+												router.history.back()
+												return
+											}
+
+											router.navigate({ to: '/app/settings', replace: true })
+										}}
+										sx={{ maxWidth: 400 }}
+									>
+										{t(m.cancel)}
+									</Button>
+
+									<form.SubmitButton
+										type="submit"
+										form={FORM_ID}
+										fullWidth
+										disableElevation
+										variant="contained"
+										size="large"
+										loading={isSubmitting}
+										loadingPosition="start"
+										aria-disabled={!canSubmit}
+										sx={{ maxWidth: 400 }}
+									>
+										{t(m.save)}
+									</form.SubmitButton>
+								</>
+							)}
+						</form.Subscribe>
+					</Stack>
+				</Stack>
+			</Stack>
+		</>
+	)
 }
+
+const m = defineMessages({
+	navTitle: {
+		id: 'routes.app.settings.device-name.navTitle',
+		defaultMessage: 'Device Name',
+		description: 'Title of the device name settings page.',
+	},
+	inputLabel: {
+		id: 'routes.app.settings.device-name.inputLabel',
+		defaultMessage: 'Device Name',
+		description: 'Label for the device name input.',
+	},
+	characterCount: {
+		id: 'routes.app.settings.device-name.characterCount',
+		defaultMessage: '{count}/{max}',
+		description:
+			'Displays number of characters in input out of the maximum allowed characters.',
+	},
+	save: {
+		id: 'routes.app.settings.device-name.save',
+		defaultMessage: 'Save',
+		description: 'Label for save button.',
+	},
+	cancel: {
+		id: 'routes.app.settings.device-name.cancel',
+		defaultMessage: 'Cancel',
+		description: 'Label for cancel button.',
+	},
+})

--- a/src/renderer/src/routes/onboarding/device-name.tsx
+++ b/src/renderer/src/routes/onboarding/device-name.tsx
@@ -11,10 +11,8 @@ import * as v from 'valibot'
 import { DARKER_ORANGE, LIGHT_GREY, WHITE } from '../../colors'
 import { Icon } from '../../components/icon'
 import { useAppForm } from '../../hooks/use-app-form'
-import {
-	DEVICE_NAME_MAX_LENGTH_GRAPHEMES,
-	INPUT_NAME_MAX_BYTES,
-} from '../../lib/constants'
+import { DEVICE_NAME_MAX_LENGTH_GRAPHEMES } from '../../lib/constants'
+import { createDeviceNameSchema } from '../../lib/schemas/device-name'
 
 export const Route = createFileRoute('/onboarding/device-name')({
 	component: RouteComponent,
@@ -29,16 +27,10 @@ function RouteComponent() {
 
 	// TODO: We want to provide translated error messages that can be rendered directly
 	// Probably not ideal do this reactively but can address later
+	// TODO: We want to provide translated error messages that can be rendered directly
+	// Probably not ideal do this reactively but can address later
 	const deviceNameSchema = useMemo(() => {
-		return v.pipe(
-			v.string(),
-			v.transform((value) => {
-				return value.trim()
-			}),
-			v.minLength(1, t(m.minLengthError)),
-			v.maxGraphemes(DEVICE_NAME_MAX_LENGTH_GRAPHEMES, t(m.maxLengthError)),
-			v.maxBytes(INPUT_NAME_MAX_BYTES, t(m.maxLengthError)),
-		)
+		return createDeviceNameSchema({ formatMessage: t })
 	}, [t])
 
 	const form = useAppForm({


### PR DESCRIPTION
Closes #111 

Something to consider as a follow up is to have [navigation blocking](tanstack.com/router/latest/docs/framework/react/guide/navigation-blocking) if the input has been updated. Probably could benefit from some design confirmation though.

Rough implementation would look like this:

```tsx
<Block
	shouldBlockFn={({ action }) => {
		if (action === 'PUSH') {
			return false
		}

		if (form.state.isDefaultValue) {
			return false
		}

		return form.state.isDirty
	}}
	withResolver
>
	{({ status, reset, proceed }) => (...)}
</Block>
```

---

Preview:

<img width="600" height="1098" alt="image" src="https://github.com/user-attachments/assets/238aadc4-3a52-44e5-a703-e0f1c7d6cbf5" />

<img width="600" height="1099" alt="image" src="https://github.com/user-attachments/assets/cfc894af-ab51-4174-aa40-1c3d0f3230ed" />

<img width="600" height="1098" alt="image" src="https://github.com/user-attachments/assets/0b369f3c-c8c8-4de2-8156-07484c756f95" />
