### PR TITLE
fix: disable navigation tabs when on device name settings page

### DIFF
--- a/src/renderer/src/components/button-link.tsx
+++ b/src/renderer/src/components/button-link.tsx
@@ -2,14 +2,35 @@
  * Based on
  * https://tanstack.com/router/latest/docs/framework/react/guide/custom-link#button
  */
+import type { ComponentProps } from 'react'
 import MUIButton, { type ButtonProps } from '@mui/material/Button'
 import MUIIconButton, { type IconButtonProps } from '@mui/material/IconButton'
-import { createLink } from '@tanstack/react-router'
+import { createLink, type LinkOptions } from '@tanstack/react-router'
 
-export const ButtonLink = createLink((props: ButtonProps<'a'>) => {
+const ButtonLinkComponent = createLink((props: ButtonProps<'a'>) => {
 	return <MUIButton component="a" ref={props.ref} {...props} />
 })
 
-export const IconButtonLink = createLink((props: IconButtonProps<'a'>) => {
+export type ButtonLinkProps = Omit<
+	ComponentProps<typeof ButtonLinkComponent>,
+	keyof LinkOptions
+> &
+	LinkOptions
+
+export function ButtonLink(props: ButtonLinkProps) {
+	return <ButtonLinkComponent {...props} />
+}
+
+const IconButtonLinkComponent = createLink((props: IconButtonProps<'a'>) => {
 	return <MUIIconButton component="a" ref={props.ref} {...props} />
 })
+
+export type IconButtonLinkProps = Omit<
+	ComponentProps<typeof IconButtonLinkComponent>,
+	keyof LinkOptions
+> &
+	LinkOptions
+
+export function IconButtonLink(props: IconButtonLinkProps) {
+	return <IconButtonLinkComponent {...props} />
+}

--- a/src/renderer/src/lib/navigation.ts
+++ b/src/renderer/src/lib/navigation.ts
@@ -1,0 +1,10 @@
+import type { FileRouteTypes, FileRoutesByTo } from '../routeTree.gen'
+
+export type ToRoute = FileRouteTypes['to']
+
+export type ToRouteParams<T extends ToRoute> =
+	keyof FileRoutesByTo[T]['options']['params']
+
+export type ToRouteFullPath = FileRouteTypes['fullPaths']
+
+export type ToRouteId = FileRouteTypes['id']

--- a/src/renderer/src/routes/app/route.tsx
+++ b/src/renderer/src/routes/app/route.tsx
@@ -124,17 +124,6 @@ function RouteComponent() {
 									pageHasEditing &&
 									!currentRoute.fullPath.startsWith('/app/settings')
 								}
-								onClick={
-									// Prevent the default behavior when clicking on the tab item
-									// within an editing page
-									pageHasEditing &&
-									currentRoute.fullPath.startsWith('/app/settings')
-										? (event) => {
-												event.preventDefault()
-												return false
-											}
-										: undefined
-								}
 								label={t(m.appSettingsTabLabel)}
 								icon={<Icon name="material-settings" size={30} />}
 							/>

--- a/src/renderer/src/routes/app/route.tsx
+++ b/src/renderer/src/routes/app/route.tsx
@@ -7,13 +7,18 @@ import {
 	Outlet,
 	createFileRoute,
 	redirect,
-	type LinkOptions,
+	useChildMatches,
 } from '@tanstack/react-router'
 import { defineMessages, useIntl } from 'react-intl'
 
 import { BLUE_GREY, COMAPEO_BLUE, DARK_GREY, WHITE } from '../../colors'
-import { ButtonLink, IconButtonLink } from '../../components/button-link'
+import {
+	ButtonLink,
+	IconButtonLink,
+	type ButtonLinkProps,
+} from '../../components/button-link'
 import { Icon } from '../../components/icon'
+import type { ToRouteFullPath } from '../../lib/navigation'
 
 export const Route = createFileRoute('/app')({
 	beforeLoad: ({ context, matches }) => {
@@ -44,6 +49,14 @@ function RouteComponent() {
 		select: ({ activeProjectId }) => activeProjectId,
 	})
 
+	const currentRoute = useChildMatches({
+		select: (matches) => {
+			return matches.at(-1)!
+		},
+	})
+
+	const pageHasEditing = checkPageHasEditing(currentRoute.fullPath)
+
 	return (
 		<Box bgcolor={WHITE} height="100vh">
 			<Box display="grid" gridTemplateColumns="min-content 1fr" height="100%">
@@ -70,6 +83,10 @@ function RouteComponent() {
 						<ListItem {...SHARED_NAV_ITEM_PROPS.listItem}>
 							<IconButtonLink
 								{...SHARED_NAV_ITEM_PROPS.link}
+								disabled={
+									pageHasEditing &&
+									currentRoute.fullPath !== '/app/projects/$projectId'
+								}
 								to="/app/projects/$projectId"
 								params={{ projectId: activeProjectId }}
 								activeProps={{
@@ -92,18 +109,42 @@ function RouteComponent() {
 							<LabeledNavItem
 								// @ts-expect-error Not implemented yet
 								to="/app/projects/$projectId/exchange"
+								disabled={
+									pageHasEditing &&
+									// @ts-expect-error Not implemented yet
+									currentRoute.fullPath !== '/app/projects/$projectId/exchange'
+								}
 								label={t(m.exchangeTabLabel)}
 								icon={<Icon name="material-offline-bolt" size={30} />}
 							/>
 
 							<LabeledNavItem
 								to="/app/settings"
+								disabled={
+									pageHasEditing &&
+									!currentRoute.fullPath.startsWith('/app/settings')
+								}
+								onClick={
+									// Prevent the default behavior when clicking on the tab item
+									// within an editing page
+									pageHasEditing &&
+									currentRoute.fullPath.startsWith('/app/settings')
+										? (event) => {
+												event.preventDefault()
+												return false
+											}
+										: undefined
+								}
 								label={t(m.appSettingsTabLabel)}
 								icon={<Icon name="material-settings" size={30} />}
 							/>
 
 							<LabeledNavItem
 								to="/app/data-and-privacy"
+								disabled={
+									pageHasEditing &&
+									currentRoute.fullPath !== '/app/data-and-privacy'
+								}
 								label={t(m.dataAndPrivacyTabLabel)}
 								icon={
 									<Icon name="material-symbols-encrypted-weight400" size={30} />
@@ -112,6 +153,9 @@ function RouteComponent() {
 
 							<LabeledNavItem
 								to="/app/about"
+								disabled={
+									pageHasEditing && currentRoute.fullPath !== '/app/about'
+								}
 								label={t(m.aboutTabLabel)}
 								icon={<Icon name="material-symbols-info" size={30} />}
 							/>
@@ -130,7 +174,7 @@ function LabeledNavItem({
 	icon,
 	label,
 	...linkOptions
-}: LinkOptions & {
+}: ButtonLinkProps & {
 	icon: ReactNode
 	label: string
 }) {
@@ -182,6 +226,14 @@ const SHARED_NAV_ITEM_PROPS = {
 		},
 	},
 } as const
+
+function checkPageHasEditing(currentPath: ToRouteFullPath) {
+	if (currentPath === '/app/settings/device-name') {
+		return true
+	}
+
+	return false
+}
 
 const m = defineMessages({
 	aboutTabLabel: {


### PR DESCRIPTION
Forgot to implement as part of #133.

---

Preview:

<img width="600" height="549" alt="image" src="https://github.com/user-attachments/assets/dce290bf-0f87-4ce5-a027-e1dde04a171a" />
