### PR TITLE
enable automatic code splitting

### DIFF
--- a/src/renderer/vite.config.js
+++ b/src/renderer/vite.config.js
@@ -34,6 +34,7 @@ export default defineConfig((configEnv) => {
 		plugins: [
 			// TanStackRouterVite({ routeFileIgnorePattern: '\\.test\\.tsx?$' }),
 			tanstackRouter({
+				autoCodeSplitting: true,
 				routeFileIgnorePattern: '\\.test\\.tsx?$',
 				routesDirectory: fileURLToPath(
 					new URL('./src/routes', import.meta.url),


### PR DESCRIPTION
Seems to just work without any extra configuration - nice!

Results when running `npm run vite:build` (aka `vite build src/renderer`):

Before:

```console
vite v7.0.5 building for production...
Generated route tree in 439ms
✓ 882 modules transformed.
../../dist/renderer/index.html                                                0.38 kB │ gzip:   0.26 kB
../../dist/renderer/assets/rubik-hebrew-wght-normal-aKm06Uuc.woff2            9.36 kB
../../dist/renderer/assets/rubik-cyrillic-ext-wght-normal-BjodpZir.woff2     12.39 kB
../../dist/renderer/assets/rubik-cyrillic-wght-normal-DveCct9I.woff2         15.11 kB
../../dist/renderer/assets/rubik-latin-ext-wght-normal-BmHZjB9M.woff2        19.51 kB
../../dist/renderer/assets/icons-sprite-C-J_6l-0.svg                         29.58 kB │ gzip:   8.96 kB
../../dist/renderer/assets/rubik-arabic-wght-normal-CZKz9PFy.woff2           32.46 kB
../../dist/renderer/assets/rubik-latin-wght-normal-CnQIisVs.woff2            35.35 kB
../../dist/renderer/assets/topographic-print-CoYrXXYl.svg                 1,148.04 kB │ gzip: 469.57 kB
../../dist/renderer/assets/index-DT4cyHGw.css                                71.63 kB │ gzip:  10.74 kB
../../dist/renderer/assets/es-Bndesf3R.js                                     0.27 kB │ gzip:   0.18 kB
../../dist/renderer/assets/pt-DZF3vM3k.js                                     0.27 kB │ gzip:   0.18 kB
../../dist/renderer/assets/en-C7HuAd7v.js                                    24.60 kB │ gzip:   4.95 kB
../../dist/renderer/assets/index-LZmpMvo1.js                                859.01 kB │ gzip: 257.58 kB
../../dist/renderer/assets/maplibre-gl-EL1WirBC.js                          938.92 kB │ gzip: 255.91 kB
```

After:

```console
vite v7.0.5 building for production...
Generated route tree in 446ms
✓ 915 modules transformed.
../../dist/renderer/index.html                                                0.38 kB │ gzip:   0.27 kB
../../dist/renderer/assets/rubik-hebrew-wght-normal-aKm06Uuc.woff2            9.36 kB
../../dist/renderer/assets/rubik-cyrillic-ext-wght-normal-BjodpZir.woff2     12.39 kB
../../dist/renderer/assets/rubik-cyrillic-wght-normal-DveCct9I.woff2         15.11 kB
../../dist/renderer/assets/rubik-latin-ext-wght-normal-BmHZjB9M.woff2        19.51 kB
../../dist/renderer/assets/icons-sprite-C-J_6l-0.svg                         29.58 kB │ gzip:   8.96 kB
../../dist/renderer/assets/rubik-arabic-wght-normal-CZKz9PFy.woff2           32.46 kB
../../dist/renderer/assets/rubik-latin-wght-normal-CnQIisVs.woff2            35.35 kB
../../dist/renderer/assets/topographic-print-CoYrXXYl.svg                 1,148.04 kB │ gzip: 469.57 kB
../../dist/renderer/assets/index-ClxHUKFO.css                                 2.28 kB │ gzip:   0.78 kB
../../dist/renderer/assets/map-C1BAJi09.css                                  69.35 kB │ gzip:   9.97 kB
../../dist/renderer/assets/constants-B1vEJQYQ.js                              0.07 kB │ gzip:   0.08 kB
../../dist/renderer/assets/route-CQ065IMY.js                                  0.11 kB │ gzip:   0.12 kB
../../dist/renderer/assets/index-pnOzNqrB.js                                  0.13 kB │ gzip:   0.14 kB
../../dist/renderer/assets/background-map-CrN_VJro.js                         0.16 kB │ gzip:   0.16 kB
../../dist/renderer/assets/isMuiElement-C56QdwTu.js                           0.16 kB │ gzip:   0.16 kB
../../dist/renderer/assets/index-5SQKS_Nb.js                                  0.18 kB │ gzip:   0.17 kB
../../dist/renderer/assets/route-DCeQfV0v.js                                  0.19 kB │ gzip:   0.17 kB
../../dist/renderer/assets/route-BGwX5zYL.js                                  0.20 kB │ gzip:   0.17 kB
../../dist/renderer/assets/route-lHQ9lgbT.js                                  0.20 kB │ gzip:   0.17 kB
../../dist/renderer/assets/index-BCVtK2He.js                                  0.20 kB │ gzip:   0.18 kB
../../dist/renderer/assets/device-DmNGsbxx.js                                 0.26 kB │ gzip:   0.20 kB
../../dist/renderer/assets/es-Bndesf3R.js                                     0.27 kB │ gzip:   0.18 kB
../../dist/renderer/assets/pt-DZF3vM3k.js                                     0.27 kB │ gzip:   0.18 kB
../../dist/renderer/assets/project-BgP80RKY.js                                0.41 kB │ gzip:   0.24 kB
../../dist/renderer/assets/queries-BMgiJMtj.js                                0.60 kB │ gzip:   0.30 kB
../../dist/renderer/assets/formControlState-DDap4IPg.js                       0.64 kB │ gzip:   0.42 kB
../../dist/renderer/assets/mergeSlotProps-CRfjqRXy.js                         0.96 kB │ gzip:   0.46 kB
../../dist/renderer/assets/route-C3nVJkLz.js                                  1.12 kB │ gzip:   0.64 kB
../../dist/renderer/assets/isHostComponent-Desr6eUg.js                        1.17 kB │ gzip:   0.62 kB
../../dist/renderer/assets/documents-DZAVwLHn.js                              1.27 kB │ gzip:   0.51 kB
../../dist/renderer/assets/about-DfUzmI28.js                                  1.28 kB │ gzip:   0.62 kB
../../dist/renderer/assets/success-B0bL5qc7.js                                1.47 kB │ gzip:   0.72 kB
../../dist/renderer/assets/projects-P8RyQhLL.js                               1.64 kB │ gzip:   0.45 kB
../../dist/renderer/assets/_projectId.success-BsQjRAxT.js                     1.65 kB │ gzip:   0.76 kB
../../dist/renderer/assets/useSlot--_7LB2QQ.js                                1.74 kB │ gzip:   0.76 kB
../../dist/renderer/assets/Container-CcH2cI-c.js                              1.99 kB │ gzip:   0.84 kB
../../dist/renderer/assets/Stack-CisZ9nzr.js                                  2.16 kB │ gzip:   1.08 kB
../../dist/renderer/assets/_projectId.success-CMmpyhPa.js                     2.21 kB │ gzip:   0.91 kB
../../dist/renderer/assets/language-BmmRSSh6.js                               2.32 kB │ gzip:   1.12 kB
../../dist/renderer/assets/icon-Ri8m2-yB.js                                   2.45 kB │ gzip:   1.17 kB
../../dist/renderer/assets/FormControl-Cn8rOsDA.js                            2.51 kB │ gzip:   1.23 kB
../../dist/renderer/assets/index-5Li2NkmV.js                                  2.59 kB │ gzip:   1.10 kB
../../dist/renderer/assets/data-and-privacy-QDFozJxj.js                       2.77 kB │ gzip:   1.06 kB
../../dist/renderer/assets/Checkbox-7gGBh5WB.js                               3.00 kB │ gzip:   1.33 kB
../../dist/renderer/assets/index-Cdc1XkK8.js                                  3.11 kB │ gzip:   1.25 kB
../../dist/renderer/assets/route-CJiHJLiU.js                                  3.18 kB │ gzip:   1.20 kB
../../dist/renderer/assets/device-name-CbtdYmo4.js                            3.39 kB │ gzip:   1.48 kB
../../dist/renderer/assets/route-CJMBNV-q.js                                  3.46 kB │ gzip:   1.47 kB
../../dist/renderer/assets/index-Bodj1SYv.js                                  3.62 kB │ gzip:   1.55 kB
../../dist/renderer/assets/data-and-privacy-CtX_J5Hl.js                       3.66 kB │ gzip:   1.45 kB
../../dist/renderer/assets/index-DU4wYYa4.js                                  3.83 kB │ gzip:   1.34 kB
../../dist/renderer/assets/categories-DNmyRlKM.js                             3.91 kB │ gzip:   1.53 kB
../../dist/renderer/assets/Divider-jHMrl4Mw.js                                3.94 kB │ gzip:   1.35 kB
../../dist/renderer/assets/utils-CF7D_7W9.js                                  4.15 kB │ gzip:   1.52 kB
../../dist/renderer/assets/device-name-CSKybf0w.js                            4.21 kB │ gzip:   1.67 kB
../../dist/renderer/assets/index-B7VaGGnd.js                                  4.33 kB │ gzip:   1.51 kB
../../dist/renderer/assets/coordinate-system-CioQ0llP.js                      4.33 kB │ gzip:   1.92 kB
../../dist/renderer/assets/ListItem-AUUUFjO0.js                               4.37 kB │ gzip:   1.62 kB
../../dist/renderer/assets/index-_IG-XFNb.js                                  4.49 kB │ gzip:   1.41 kB
../../dist/renderer/assets/RadioGroup-DvBIDZ4q.js                             4.92 kB │ gzip:   2.08 kB
../../dist/renderer/assets/FormGroup-Brl23L8b.js                              5.63 kB │ gzip:   2.29 kB
../../dist/renderer/assets/team-D5CwPxZd.js                                   8.71 kB │ gzip:   2.28 kB
../../dist/renderer/assets/info-BN6tuwdH.js                                   9.23 kB │ gzip:   2.56 kB
../../dist/renderer/assets/welcome-05OSng3I.js                               11.25 kB │ gzip:   4.39 kB
../../dist/renderer/assets/map-CCh6HOMW.js                                   15.16 kB │ gzip:   5.47 kB
../../dist/renderer/assets/privacy-policy-BxsRylWe.js                        15.69 kB │ gzip:   4.95 kB
../../dist/renderer/assets/test-data-BBuP_M8B.js                             21.43 kB │ gzip:   7.53 kB
../../dist/renderer/assets/en-C7HuAd7v.js                                    24.60 kB │ gzip:   4.95 kB
../../dist/renderer/assets/forms-Bdw_f_YR.js                                 94.99 kB │ gzip:  27.84 kB
../../dist/renderer/assets/index-nA9OVYHp.js                                598.59 kB │ gzip: 188.57 kB
../../dist/renderer/assets/maplibre-gl-C8la2kH9.js                          938.93 kB │ gzip: 255.92 kB
```

Most notably, the unzipped size of our entry goes down from 859.01 kB to 598.59 kB ✨ 