### PR TITLE
fix: use a more flexible schema for config store

### DIFF
--- a/src/main/config-store.js
+++ b/src/main/config-store.js
@@ -1,20 +1,15 @@
 import Store from 'electron-store'
 
-/**
- * @import {ConfigSchema} from './types/config-store.js'
- */
-
 /** @typedef {ReturnType<typeof createConfigStore>} ConfigStore */
 
 export function createConfigStore() {
 	const store = /**
-	 * @type {Store<ConfigSchema>}
+	 * @type {Store<import('./types/config-store.js').ConfigSchema>}
 	 */ (
 		new Store({
 			schema: {
 				activeProjectId: {
-					type: ['string', 'null'],
-					default: null,
+					type: ['string'],
 				},
 				coordinateFormat: {
 					type: ['string'],
@@ -62,8 +57,7 @@ export function createConfigStore() {
 					},
 				},
 				rootKey: {
-					type: ['string', 'null'],
-					default: null,
+					type: ['string'],
 				},
 			},
 		})

--- a/src/main/types/config-store.ts
+++ b/src/main/types/config-store.ts
@@ -1,19 +1,15 @@
-export type PersistedLocale =
-	| {
-			useSystemPreferences: true
-			languageTag: null
-	  }
-	| {
-			useSystemPreferences: false
-			languageTag: string
-	  }
+import { type InferOutput } from 'valibot'
+
+import { PersistedLocaleSchema } from '../validation.js'
+
+export type PersistedLocale = InferOutput<typeof PersistedLocaleSchema>
 
 export type PersistedCoordinateFormat = 'dd' | 'dms' | 'utm'
 
 export type ConfigSchema = {
-	activeProjectId: string | null
+	activeProjectId?: string
 	coordinateFormat: PersistedCoordinateFormat
 	diagnosticsEnabled: boolean
 	locale: PersistedLocale
-	rootKey: string | null
+	rootKey?: string
 }

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -1,18 +1,7 @@
 import isDev from 'electron-is-dev'
 import * as v from 'valibot'
 
-const AppEnvSchema = v.object({
-	asar: v.optional(
-		v.pipe(
-			v.union([v.literal('true'), v.literal('false')]),
-			v.transform((value) => {
-				return value === 'true'
-			}),
-		),
-	),
-	onlineStyleUrl: v.pipe(v.string(), v.url()),
-	userDataPath: v.optional(v.string()),
-})
+import { AppEnvSchema } from './validation.js'
 
 /**
  * @typedef {v.InferOutput<typeof AppEnvSchema>} AppEnv

--- a/src/main/validation.js
+++ b/src/main/validation.js
@@ -1,0 +1,36 @@
+import * as v from 'valibot'
+
+export const AppEnvSchema = v.object({
+	asar: v.optional(
+		v.pipe(
+			v.union([v.literal('true'), v.literal('false')]),
+			v.transform((value) => {
+				return value === 'true'
+			}),
+		),
+	),
+	onlineStyleUrl: v.pipe(v.string(), v.url()),
+	userDataPath: v.optional(v.string()),
+})
+
+export const FilesSelectParamsSchema = v.union([
+	v.object({ extensionFilters: v.optional(v.array(v.string())) }),
+	v.undefined(),
+])
+
+export const PersistedLocaleSchema = v.variant('useSystemPreferences', [
+	v.object({
+		useSystemPreferences: v.literal(true),
+		languageTag: v.null(),
+	}),
+	v.object({
+		useSystemPreferences: v.literal(false),
+		languageTag: v.string(),
+	}),
+])
+
+export const PersistedCoordinateFormatSchema = v.union([
+	v.literal('dd'),
+	v.literal('dms'),
+	v.literal('utm'),
+])

--- a/src/preload/runtime.ts
+++ b/src/preload/runtime.ts
@@ -22,7 +22,7 @@ export type RuntimeApi = {
 	openExternalURL: (url: string) => Promise<void>
 
 	// Settings (get)
-	getActiveProjectId: () => Promise<string | null>
+	getActiveProjectId: () => Promise<string | undefined>
 	getCoordinateFormat: () => Promise<PersistedCoordinateFormat>
 	getDiagnosticsEnabled: () => Promise<boolean>
 	getLocaleState: () => Promise<LocaleState>

--- a/src/renderer/src/lib/queries/app-settings.ts
+++ b/src/renderer/src/lib/queries/app-settings.ts
@@ -13,7 +13,9 @@ export function getActiveProjectIdQueryOptions() {
 	return queryOptions({
 		queryKey: [BASE_QUERY_KEY, 'activeProjectId'],
 		queryFn: async () => {
-			return window.runtime.getActiveProjectId()
+			// Query functions cannot return undefined so we return null in this case
+			const result = await window.runtime.getActiveProjectId()
+			return result === undefined ? null : result
 		},
 	})
 }


### PR DESCRIPTION
Updates the config store schema to allow optional fields to be represented as missing keys in the config store JSON file. This makes updating the schema with new fields easier once it's out in the wild.