### PR TITLE
fix: fix the background color in the empty panel on exchange page

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId_/exchange/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/exchange/index.tsx
@@ -27,6 +27,7 @@ import {
 	DARKER_ORANGE,
 	GREEN,
 	LIGHT_COMAPEO_BLUE,
+	LIGHT_GREY,
 	WHITE,
 } from '../../../../../colors'
 import { Icon } from '../../../../../components/icon'
@@ -222,7 +223,7 @@ function RouteComponent() {
 					</Box>
 				</Stack>
 			}
-			end={null}
+			end={<Box bgcolor={LIGHT_GREY} display="flex" flex={1} />}
 		/>
 	)
 }


### PR DESCRIPTION
Quick follow-up to #168 as I forgot to specify the the empty panel's background color

---

Preview:

<img width="600" height="1098" alt="image" src="https://github.com/user-attachments/assets/55bbfd24-44ee-4ed9-96dc-dabfc2d2a549" />
