### PR TITLE
fix: update logic for category matching

### DIFF
--- a/src/renderer/src/lib/comapeo.ts
+++ b/src/renderer/src/lib/comapeo.ts
@@ -1,5 +1,5 @@
 import type { MemberInfo } from '@comapeo/core/dist/member-api'
-import type { Observation, Preset } from '@comapeo/schema'
+import type { Observation, Preset, Track } from '@comapeo/schema'
 
 // https://github.com/digidem/comapeo-core-react/blob/e56979321e91440ad6e291521a9e3ce8eb91200d/src/lib/react-query/shared.ts#L6C1-L6C52
 export const COMAPEO_CORE_REACT_ROOT_QUERY_KEY = '@comapeo/core-react' as const
@@ -20,8 +20,8 @@ export const NO_ROLE_ID = '08e4251e36f6e7ed'
  * convention. This approach allows for tags to be edited and changed in a
  * preset while still maintaining backwards compatibility when necessary.
  */
-export function getCategoryBasedOnObservationTags(
-	observationTags: Observation['tags'],
+function getCategoryUsingTags(
+	tags: Observation['tags'] | Track['tags'],
 	presets: Array<Preset>,
 ): Preset | undefined {
 	let bestMatch: Preset | undefined
@@ -35,7 +35,7 @@ export function getCategoryBasedOnObservationTags(
 			// eslint-disable-next-line no-prototype-builtins
 			if (preset.tags.hasOwnProperty(key)) {
 				const presetTag = preset.tags[key]
-				const availableTag = observationTags[key]
+				const availableTag = tags[key]
 				if (presetTag === availableTag) {
 					score++
 				} else if (
@@ -58,6 +58,19 @@ export function getCategoryBasedOnObservationTags(
 	})
 
 	return bestMatch
+}
+
+export function getMatchingCategoryForDocument(
+	document: Observation | Track,
+	categories: Array<Preset>,
+) {
+	let result = getCategoryUsingTags(document.tags, categories)
+
+	if (!result && document.presetRef?.docId) {
+		result = categories.find((c) => c.docId === document.presetRef?.docId)
+	}
+
+	return result
 }
 
 export type ActiveRemoteArchiveMemberInfo = MemberInfo & {

--- a/src/renderer/src/routes/app/projects/$projectId/-displayed-data/list.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/-displayed-data/list.tsx
@@ -37,7 +37,7 @@ import {
 } from '../../../../../colors'
 import { Icon } from '../../../../../components/icon'
 import { TextLink } from '../../../../../components/link'
-import { getCategoryBasedOnObservationTags } from '../../../../../lib/comapeo'
+import { getMatchingCategoryForDocument } from '../../../../../lib/comapeo'
 import { getLocaleStateQueryOptions } from '../../../../../lib/queries/app-settings'
 
 const APPROXIMATE_ITEM_HEIGHT_PX = 100
@@ -74,32 +74,18 @@ export function DisplayedDataList({ projectId }: { projectId: string }) {
 	})
 
 	const observationsWithCategory = useMemo(() => {
-		return observations.map((o) => {
-			let category: Preset | undefined = undefined
-
-			if (o.presetRef?.docId) {
-				category = categories.find((c) => c.docId === o.presetRef?.docId)
-			}
-
-			if (!category) {
-				category = getCategoryBasedOnObservationTags(o.tags, categories)
-			}
-
-			return {
-				type: 'observation' as const,
-				document: o,
-				category,
-			}
-		})
+		return observations.map((o) => ({
+			type: 'observation' as const,
+			document: o,
+			category: getMatchingCategoryForDocument(o, categories),
+		}))
 	}, [observations, categories])
 
 	const tracksWithCategory = useMemo(() => {
 		return tracks.map((t) => ({
 			type: 'track' as const,
 			document: t,
-			category: t.presetRef?.docId
-				? categories.find((c) => c.docId === t.presetRef?.docId)
-				: undefined,
+			category: getMatchingCategoryForDocument(t, categories),
 		}))
 	}, [tracks, categories])
 

--- a/src/renderer/src/routes/app/projects/$projectId/-displayed-data/map.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/-displayed-data/map.tsx
@@ -26,7 +26,7 @@ import * as v from 'valibot'
 
 import { BLACK, ORANGE, WHITE } from '../../../../../colors'
 import { Map } from '../../../../../components/map'
-import { getCategoryBasedOnObservationTags } from '../../../../../lib/comapeo'
+import { getMatchingCategoryForDocument } from '../../../../../lib/comapeo'
 import { getLocaleStateQueryOptions } from '../../../../../lib/queries/app-settings'
 
 const OBSERVATIONS_SOURCE_ID = 'observations_source'
@@ -402,15 +402,7 @@ function observationsToFeatureCollection(
 
 	for (const obs of observations) {
 		if (typeof obs.lon === 'number' && typeof obs.lat === 'number') {
-			let category: Preset | undefined = undefined
-
-			if (obs.presetRef?.docId) {
-				category = categories.find((c) => c.docId === obs.presetRef?.docId)
-			}
-
-			if (!category) {
-				category = getCategoryBasedOnObservationTags(obs.tags, categories)
-			}
+			const category = getMatchingCategoryForDocument(obs, categories)
 
 			displayablePoints.push(
 				point([obs.lon, obs.lat], {


### PR DESCRIPTION
Follow-up to #172 because it turns out I don't know how categories are supposed to be matched 😅  The general approach is:

1. Use the document's `tags` field to determine if there's a matching preset
2. If (1) comes up empty, then use the document's `presetRef` to determine the matching preset.

For posterity, the reasoning as explained by Gregor:

> The reason for this is to support updating of the project presets / config: say a user has a preset for "bridge" and a question about what type of bridge it is, then in the next iteration of the config, the user creates a different preset for each type of bridge (matching on the bridge type tag), then we want existing data to match the correct bridge type preset, rather than use the "parent" generic bridge preset. This is how iDEditor implements preset matching and there is a power to it for evolving data models without needing to reclassify / re-write everything.