### PR TITLE
feat: display observation attachments listed data

### DIFF
--- a/src/renderer/icons/material-error.svg
+++ b/src/renderer/icons/material-error.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>

--- a/src/renderer/src/components/category-icon.tsx
+++ b/src/renderer/src/components/category-icon.tsx
@@ -21,6 +21,7 @@ export function CategoryIconContainer({
 			flexDirection="column"
 			justifyContent="center"
 			alignItems="center"
+			flex={1}
 			bgcolor={WHITE}
 			borderRadius="50%"
 			padding={padding}

--- a/src/renderer/src/components/error-boundary.tsx
+++ b/src/renderer/src/components/error-boundary.tsx
@@ -1,0 +1,25 @@
+import type { ErrorInfo, ReactElement, ReactNode } from 'react'
+// NOTE: Not sure if using CatchBoundary is really safe to use for generic purposes. Might need to switch to `react-error-boundary`.
+import { CatchBoundary, type ErrorComponentProps } from '@tanstack/react-router'
+
+export function ErrorBoundary({
+	children,
+	fallback,
+	getResetKey,
+	onError,
+}: {
+	children: ReactNode
+	getResetKey: () => number | string
+	fallback: (props: ErrorComponentProps) => ReactElement
+	onError?: (error: Error, errorInfo?: ErrorInfo) => void
+}) {
+	return (
+		<CatchBoundary
+			getResetKey={getResetKey}
+			errorComponent={fallback}
+			onCatch={onError}
+		>
+			{children}
+		</CatchBoundary>
+	)
+}

--- a/src/renderer/src/components/suspense-image.tsx
+++ b/src/renderer/src/components/suspense-image.tsx
@@ -1,0 +1,12 @@
+// Adapted version of https://suspense.epicreact.dev/exercise/04/01/solution
+import { use, type ComponentProps } from 'react'
+
+import { imageSrcResource } from '../lib/image'
+
+type SuspenseImageProps = ComponentProps<'img'> &
+	Required<Pick<ComponentProps<'img'>, 'src'>>
+
+export function SuspenseImage({ src, ...props }: SuspenseImageProps) {
+	const s = use(imageSrcResource(src))
+	return <img src={s} {...props} />
+}

--- a/src/renderer/src/images/icons-sprite.svg
+++ b/src/renderer/src/images/icons-sprite.svg
@@ -394,6 +394,11 @@
 			<path d="M0 0h24v24H0z" fill="none"></path>
 			<path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"></path>
 		</symbol>
+		<symbol viewBox="0 0 24 24" id="material-error">
+			<path
+				d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+			></path>
+		</symbol>
 		<symbol viewBox="0 0 24 24" id="material-chevron-right">
 			<path fill="none" d="M0 0h24v24H0V0z"></path>
 			<path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6-6-6z"></path>

--- a/src/renderer/src/lib/comapeo.ts
+++ b/src/renderer/src/lib/comapeo.ts
@@ -1,6 +1,8 @@
 import type { MemberInfo } from '@comapeo/core/dist/member-api'
 import type { Field, Observation, Preset, Track } from '@comapeo/schema'
 
+export type Attachment = Observation['attachments'][number]
+
 // https://github.com/digidem/comapeo-core-react/blob/e56979321e91440ad6e291521a9e3ce8eb91200d/src/lib/react-query/shared.ts#L6C1-L6C52
 export const COMAPEO_CORE_REACT_ROOT_QUERY_KEY = '@comapeo/core-react' as const
 

--- a/src/renderer/src/lib/image.ts
+++ b/src/renderer/src/lib/image.ts
@@ -1,0 +1,21 @@
+// Adapted version of https://suspense.epicreact.dev/exercise/04/01/solution
+const imageCache = new Map<string, Promise<string>>()
+
+function preloadImage(src: string) {
+	const { resolve, reject, promise } = Promise.withResolvers<string>()
+	const image = new Image()
+
+	image.src = src
+	image.onload = () => resolve(src)
+	image.onerror = reject
+
+	return promise
+}
+
+export function imageSrcResource(src: string) {
+	const promise = imageCache.get(src) ?? preloadImage(src)
+
+	imageCache.set(src, promise)
+
+	return promise
+}

--- a/src/renderer/src/routes/app/projects/$projectId/-displayed-data/list.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/-displayed-data/list.tsx
@@ -4,16 +4,19 @@ import {
 	useEffect,
 	useMemo,
 	useRef,
+	type CSSProperties,
 	type FocusEvent,
 	type MouseEvent,
 	type RefObject,
 } from 'react'
 import {
+	useAttachmentUrl,
 	useDocumentCreatedBy,
 	useIconUrl,
 	useManyDocs,
 	useOwnDeviceInfo,
 } from '@comapeo/core-react'
+import type { BlobId } from '@comapeo/core/dist/types'
 import type { Observation, Preset, Track } from '@comapeo/schema'
 import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
@@ -28,6 +31,7 @@ import { defineMessages, useIntl } from 'react-intl'
 import scrollIntoView from 'scroll-into-view-if-needed'
 
 import {
+	BLACK,
 	BLUE_GREY,
 	COMAPEO_BLUE,
 	LIGHT_COMAPEO_BLUE,
@@ -37,10 +41,14 @@ import {
 import { CategoryIconContainer } from '../../../../../components/category-icon'
 import { Icon } from '../../../../../components/icon'
 import { TextLink } from '../../../../../components/link'
-import { getMatchingCategoryForDocument } from '../../../../../lib/comapeo'
+import {
+	getMatchingCategoryForDocument,
+	type Attachment,
+} from '../../../../../lib/comapeo'
 import { getLocaleStateQueryOptions } from '../../../../../lib/queries/app-settings'
 
-const APPROXIMATE_ITEM_HEIGHT_PX = 100
+const CATEGORY_CONTAINER_SIZE_PX = 64
+const APPROXIMATE_ITEM_HEIGHT_PX = CATEGORY_CONTAINER_SIZE_PX + 16 * 2
 
 export function DisplayedDataList({ projectId }: { projectId: string }) {
 	const { formatMessage: t, formatDate } = useIntl()
@@ -295,33 +303,38 @@ export function DisplayedDataList({ projectId }: { projectId: string }) {
 										display="flex"
 										justifyContent="center"
 										alignItems="center"
+										width={CATEGORY_CONTAINER_SIZE_PX}
+										sx={{ aspectRatio: 1 }}
 									>
-										{category?.iconRef?.docId ? (
-											<Suspense
-												fallback={
-													<Box
-														display="flex"
-														justifyContent="center"
-														alignItems="center"
-														height={48}
-														width={48}
-													>
-														<CircularProgress disableShrink size={30} />
-													</Box>
-												}
-											>
-												<DisplayedCategoryAndAttachments
+										<Suspense
+											fallback={
+												<Box
+													display="flex"
+													justifyContent="center"
+													alignItems="center"
+													flex={1}
+												>
+													<CircularProgress disableShrink size={30} />
+												</Box>
+											}
+										>
+											{type === 'observation' ? (
+												<ObservationCategory
+													attachments={document.attachments}
+													categoryColor={category?.color}
+													categoryName={category?.name}
+													categoryIconDocumentId={category?.iconRef?.docId}
 													projectId={projectId}
-													categoryName={category.name}
-													borderColor={category.color || BLUE_GREY}
-													iconDocumentId={category.iconRef.docId}
 												/>
-											</Suspense>
-										) : (
-											<CategoryIconContainer color={BLUE_GREY}>
-												<Icon name="material-place" size={40} />
-											</CategoryIconContainer>
-										)}
+											) : (
+												<TrackCategory
+													categoryIconDocumentId={category?.iconRef?.docId}
+													categoryColor={category?.color}
+													categoryName={category?.name}
+													projectId={projectId}
+												/>
+											)}
+										</Suspense>
 									</Box>
 								</Stack>
 							</ListItemButton>
@@ -391,17 +404,163 @@ function SyncedIndicatorLine({
 	) : null
 }
 
-// TODO: Display attachments
-function DisplayedCategoryAndAttachments({
-	borderColor,
+function ObservationCategory({
+	attachments,
+	projectId,
+	categoryName,
+	categoryColor,
+	categoryIconDocumentId,
+}: {
+	attachments: Array<Attachment>
+	categoryColor?: string
+	categoryIconDocumentId?: string
+	categoryName?: string
+	projectId: string
+}) {
+	const { formatMessage: t } = useIntl()
+
+	const displayableAttachments = attachments.filter(
+		// TODO: Support other attachment types
+		(a): a is Extract<Attachment, { type: 'photo' }> => a.type === 'photo',
+	)
+
+	const color = categoryColor || BLUE_GREY
+	const name = categoryName || t(m.observationCategoryNameFallback)
+
+	if (displayableAttachments.length > 0) {
+		const shouldStack = displayableAttachments.length > 1
+
+		const categoryIcon = categoryIconDocumentId ? (
+			<CategoryIcon
+				projectId={projectId}
+				iconDocumentId={categoryIconDocumentId}
+				categoryColor={color}
+				categoryName={name}
+				imageStyle={{ aspectRatio: 1, maxHeight: 12, objectFit: 'cover' }}
+			/>
+		) : (
+			<CategoryIconContainer color={BLUE_GREY}>
+				<Icon name="material-place" size={40} />
+			</CategoryIconContainer>
+		)
+
+		return (
+			<>
+				<Box
+					overflow="hidden"
+					borderRadius={2}
+					display="flex"
+					flexDirection="column"
+					position="relative"
+					width="100%"
+					sx={{ aspectRatio: 1 }}
+				>
+					{
+						// NOTE: We only display the first three
+						displayableAttachments.slice(0, 3).map((attachment, index) => (
+							<Box
+								key={`${attachment.driveDiscoveryId}/${attachment.type}/${attachment.name}/${attachment.hash}`}
+								position="absolute"
+								sx={
+									shouldStack
+										? {
+												aspectRatio: 1,
+												outline: `1px solid ${BLUE_GREY}`,
+												width: '80%',
+												top: index * 5,
+												left: index * 5,
+											}
+										: {
+												top: 0,
+												right: 0,
+												left: 0,
+												bottom: 0,
+											}
+								}
+								overflow="hidden"
+								borderRadius={2}
+							>
+								<AttachmentImage
+									projectId={projectId}
+									blobId={{
+										driveId: attachment.driveDiscoveryId,
+										name: attachment.name,
+										variant: 'preview',
+										type: attachment.type,
+									}}
+								/>
+							</Box>
+						))
+					}
+				</Box>
+
+				<Box
+					position="absolute"
+					right={(theme) => theme.spacing(2)}
+					bottom={(theme) => theme.spacing(2)}
+					zIndex={1}
+				>
+					{categoryIcon}
+				</Box>
+			</>
+		)
+	}
+
+	return categoryIconDocumentId ? (
+		<CategoryIcon
+			projectId={projectId}
+			iconDocumentId={categoryIconDocumentId}
+			categoryColor={color}
+			categoryName={name}
+			imageStyle={{ aspectRatio: 1, width: '100%' }}
+		/>
+	) : (
+		<CategoryIconContainer color={BLUE_GREY}>
+			<Icon name="material-place" size={40} />
+		</CategoryIconContainer>
+	)
+}
+
+function TrackCategory({
+	categoryColor,
+	categoryIconDocumentId,
 	categoryName,
 	projectId,
-	iconDocumentId,
 }: {
-	borderColor: string
-	categoryName: string
 	projectId: string
+	categoryColor?: string
+	categoryIconDocumentId?: string
+	categoryName?: string
+}) {
+	const { formatMessage: t } = useIntl()
+
+	return categoryIconDocumentId ? (
+		<CategoryIcon
+			projectId={projectId}
+			iconDocumentId={categoryIconDocumentId}
+			categoryColor={categoryColor || BLUE_GREY}
+			categoryName={categoryName || t(m.trackCategoryNameFallback)}
+			imageStyle={{ aspectRatio: 1, width: '100%' }}
+		/>
+	) : (
+		<CategoryIconContainer color={BLACK}>
+			<Icon name="material-hiking" size={40} />
+		</CategoryIconContainer>
+	)
+}
+
+function CategoryIcon({
+	categoryColor,
+	categoryName,
+	iconDocumentId,
+	imageStyle,
+	projectId,
+}: {
+	categoryColor: string
+	categoryName: string
 	iconDocumentId: string
+	imageStyle?: CSSProperties
+	projectId: string
 }) {
 	const { formatMessage: t } = useIntl()
 
@@ -414,13 +573,34 @@ function DisplayedCategoryAndAttachments({
 	})
 
 	return (
-		<CategoryIconContainer color={borderColor}>
+		<CategoryIconContainer color={categoryColor}>
 			<img
 				src={iconURL}
 				alt={t(m.categoryIconAlt, { name: categoryName })}
-				style={{ aspectRatio: 1, maxHeight: 48 }}
+				style={imageStyle}
 			/>
 		</CategoryIconContainer>
+	)
+}
+
+function AttachmentImage({
+	blobId,
+	projectId,
+}: {
+	blobId: BlobId
+	projectId: string
+}) {
+	const { data: attachmentUrl } = useAttachmentUrl({ projectId, blobId })
+
+	return (
+		<img
+			src={attachmentUrl}
+			style={{
+				aspectRatio: 1,
+				width: '100%',
+				objectFit: 'cover',
+			}}
+		/>
 	)
 }
 

--- a/src/renderer/src/types/icons.generated.ts
+++ b/src/renderer/src/types/icons.generated.ts
@@ -35,6 +35,7 @@ export const iconNames = [
 	'material-explore',
 	'material-expand-more',
 	'material-expand-less',
+	'material-error',
 	'material-chevron-right',
 	'material-check',
 	'material-check-circle',


### PR DESCRIPTION
Closes #162 

- At the moment, only displays photo attachments for observations.
- If attachments are displayed, only displays the first 3
- Implements an improvised error state for attachments or categories that fail to load. Probably needs some adjustments from design and user feedback.

---

Preview:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/aab91e2d-801d-4a3d-b7d5-bad68e648eb5" />
