### PR TITLE
feat: introduce default route error component

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -11,6 +11,22 @@
     "description": "Generic title text for the error dialog.",
     "message": "Something Went Wrong"
   },
+  "components.generic-route-error-component.error": {
+    "description": "Label for error section",
+    "message": "Error"
+  },
+  "components.generic-route-error-component.reload": {
+    "description": "Button text to reload the page",
+    "message": "Reload"
+  },
+  "components.generic-route-error-component.somethinWentWrong": {
+    "description": "Title text of page error",
+    "message": "Something went wrong"
+  },
+  "components.generic-route-error-component.stacktrace": {
+    "description": "Label for stack trace section",
+    "message": "Stack trace"
+  },
   "routes.app.about.title": {
     "message": "About CoMapeo"
   },

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -20,6 +20,7 @@ import {
 
 import type { LocaleState } from '../../main/types/intl'
 import { initComapeoClient } from './comapeo-client'
+import { GenericRouteErrorComponent } from './components/generic-route-error-component'
 import { IntlProvider } from './contexts/intl'
 import { useNetworkConnectionChangeListener } from './hooks/network'
 import {
@@ -64,6 +65,7 @@ const router = createRouter({
 	// This will ensure that the loader is always called when the route is preloaded or visited
 	defaultPreloadStaleTime: 0,
 	scrollRestoration: true,
+	defaultErrorComponent: GenericRouteErrorComponent,
 })
 
 declare module '@tanstack/react-router' {

--- a/src/renderer/src/components/generic-route-error-component.tsx
+++ b/src/renderer/src/components/generic-route-error-component.tsx
@@ -1,0 +1,124 @@
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { useNavigate, type ErrorComponentProps } from '@tanstack/react-router'
+import { defineMessages, useIntl } from 'react-intl'
+
+import { BLUE_GREY, LIGHT_GREY, WHITE } from '../colors'
+
+export function GenericRouteErrorComponent({ error }: ErrorComponentProps) {
+	const navigate = useNavigate()
+
+	const { formatMessage: t } = useIntl()
+
+	return (
+		<Stack
+			bgcolor={WHITE}
+			direction="column"
+			flex={1}
+			useFlexGap
+			gap={6}
+			height="100%"
+			overflow="auto"
+		>
+			<Stack direction="column" flex={1} useFlexGap gap={6} padding={6}>
+				<Typography
+					variant="h1"
+					color="error"
+					fontWeight={500}
+					textAlign="center"
+				>
+					{t(m.somethingWentWrong)}
+				</Typography>
+
+				<Typography variant="h2" fontWeight={500}>
+					{t(m.error)}
+				</Typography>
+
+				<Box
+					bgcolor={LIGHT_GREY}
+					padding={4}
+					border={`1px solid ${BLUE_GREY}`}
+					overflow="auto"
+					borderRadius={2}
+				>
+					<Typography
+						component="pre"
+						variant="body2"
+						fontFamily="monospace"
+						whiteSpace="pre-wrap"
+						sx={{ wordBreak: 'break-word' }}
+					>
+						{error.toString()}
+					</Typography>
+				</Box>
+
+				<Typography variant="h2" fontWeight={500}>
+					{t(m.stackTrace)}
+				</Typography>
+
+				<Box
+					bgcolor={LIGHT_GREY}
+					padding={4}
+					border={`1px solid ${BLUE_GREY}`}
+					overflow="auto"
+					borderRadius={2}
+				>
+					<Typography
+						component="pre"
+						variant="body2"
+						fontFamily="monospace"
+						whiteSpace="pre-wrap"
+						sx={{ wordBreak: 'break-word' }}
+					>
+						{error.stack}
+					</Typography>
+				</Box>
+			</Stack>
+
+			<Box
+				position="sticky"
+				bottom={0}
+				padding={6}
+				display="flex"
+				justifyContent="center"
+			>
+				<Button
+					fullWidth
+					disableElevation
+					size="large"
+					onClick={() => {
+						navigate({ to: '.', reloadDocument: true })
+					}}
+					sx={{ maxWidth: 400 }}
+				>
+					{t(m.reload)}
+				</Button>
+			</Box>
+		</Stack>
+	)
+}
+
+const m = defineMessages({
+	somethingWentWrong: {
+		id: 'components.generic-route-error-component.somethinWentWrong',
+		defaultMessage: 'Something went wrong',
+		description: 'Title text of page error',
+	},
+	error: {
+		id: 'components.generic-route-error-component.error',
+		defaultMessage: 'Error',
+		description: 'Label for error section',
+	},
+	stackTrace: {
+		id: 'components.generic-route-error-component.stacktrace',
+		defaultMessage: 'Stack trace',
+		description: 'Label for stack trace section',
+	},
+	reload: {
+		id: 'components.generic-route-error-component.reload',
+		defaultMessage: 'Reload',
+		description: 'Button text to reload the page',
+	},
+})

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -5,5 +5,5 @@
 }
 
 body {
-	min-height: 100vh;
+	min-height: 100dvh;
 }

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -1,6 +1,5 @@
-import { Suspense } from 'react'
 import type { MapeoClientApi } from '@comapeo/ipc'
-import CircularProgress from '@mui/material/CircularProgress'
+import Box from '@mui/material/Box'
 import type { QueryClient } from '@tanstack/react-query'
 import { Outlet, createRootRouteWithContext } from '@tanstack/react-router'
 
@@ -15,8 +14,8 @@ export interface RootRouterContext {
 
 export const Route = createRootRouteWithContext<RootRouterContext>()({
 	component: () => (
-		<Suspense fallback={<CircularProgress />}>
+		<Box height="100dvh">
 			<Outlet />
-		</Suspense>
+		</Box>
 	),
 })

--- a/src/renderer/src/routes/app/route.tsx
+++ b/src/renderer/src/routes/app/route.tsx
@@ -62,7 +62,7 @@ function RouteComponent() {
 	const pageHasEditing = checkPageHasEditing(currentRoute.fullPath)
 
 	return (
-		<Box bgcolor={WHITE} height="100vh">
+		<Box bgcolor={WHITE} height="100%">
 			<Box display="grid" gridTemplateColumns="min-content 1fr" height="100%">
 				<Box
 					component="nav"

--- a/src/renderer/src/routes/onboarding/route.tsx
+++ b/src/renderer/src/routes/onboarding/route.tsx
@@ -80,7 +80,7 @@ function RouteComponent() {
 		currentPath === '/onboarding/project/join/$inviteId/success'
 
 	return (
-		<Box bgcolor={DARK_COMAPEO_BLUE} padding={5} height="100vh">
+		<Box bgcolor={DARK_COMAPEO_BLUE} padding={5} height="100%">
 			<Container
 				maxWidth="md"
 				component={Box}

--- a/src/renderer/src/routes/welcome.tsx
+++ b/src/renderer/src/routes/welcome.tsx
@@ -63,9 +63,9 @@ function RouteComponent() {
 
 	return (
 		<Box
+			height="100%"
 			bgcolor={DARK_COMAPEO_BLUE}
 			flexDirection="column"
-			minHeight="100vh"
 			display="flex"
 			justifyContent="center"
 			alignItems="center"


### PR DESCRIPTION
The default one from tanstack was very barebones and generally not easy to read. This PR introduces a new one that's configured to be used whenever an unhandled error is thrown within a route.

Shows the error name, a stack trace, and a button to reload the page.

---

Preview:

- Example of one near the top-level of the app

    <img width="600" height="1098" alt="image" src="https://github.com/user-attachments/assets/511803fe-d5b2-4f8a-b59c-3966d4165ce7" />

- Example of one that's within a more nested route:

    <img width="600" height="1094" alt="image" src="https://github.com/user-attachments/assets/279afb4a-fc77-4972-952c-d969924ecb94" />
