### PR TITLE
fix: fix loading of env file in packaged app

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -112,8 +112,6 @@ The [Electron Forge docs](https://www.electronforge.io/) are pretty informative 
 
 All commands place the built assets in the `out/` directory.
 
-Our build process requires a `.env.production` file to exist at the project root in order for these commands to work. Usually this file will be generated as a prerequisite to packaging the app (e.g. in continuous deployment environments like GitHub Actions). If you are just debugging locally, you can create a copy of your `.env` file and call it `.env.production` in order to avoid errors at build time.
-
 If you're running into an error with any of the Forge-related commands but not seeing any output in the console, you probably have to prefix the command with `DEBUG=electron-forge` e.g. `DEBUG=electron-forge npm run forge:package`.
 
 By default, we package the app in the [ASAR](https://github.com/electron/asar) format. However, it can be helpful to avoid doing that for debugging purposes (e.g. building locally), in which case you can specify a `ASAR=false` environment variable when running the relevant Forge command e.g. `ASAR=false npm run forge:package`.

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,18 +1,20 @@
 #!/usr/bin/env electron
 import { createRequire } from 'node:module'
 import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import debug from 'debug'
+import dotenv from 'dotenv'
 import { app } from 'electron/main'
 
 import { start } from './app.js'
 import { createConfigStore } from './config-store.js'
 import { getAppEnv, getAppMode } from './utils.js'
 
-import 'dotenv/config'
-
 const require = createRequire(import.meta.url)
 
 const log = debug('comapeo:main:index')
+
+dotenv.config({ path: fileURLToPath(new URL('../../.env', import.meta.url)) })
 
 const appEnv = getAppEnv()
 


### PR DESCRIPTION
Towards #97 

We have to tell dotenv the env file's location when it's not in the same directory as the process that starts the app.

Also uses this opportunity to simplify the build process a bit. No longer need a distinct `.env.production` file, as the plan is to generate a `.env` file in a github workflow step prior to building the app.