### PR TITLE
chore: update tsconfig to improve electron types setup

### DIFF
--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -1,4 +1,4 @@
-import { shell } from 'electron'
+import { shell } from 'electron/common'
 import { ipcMain } from 'electron/main'
 import si from 'systeminformation'
 import * as v from 'valibot'

--- a/src/preload/tsconfig.json
+++ b/src/preload/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": ["../../tsconfig.json"],
 	"compilerOptions": {
 		"lib": ["ESNext", "dom"],
-		"types": ["electron"],
 		"module": "NodeNext"
 	},
 	"include": ["**/*.js", "**/*.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,10 @@
 		"noImplicitOverride": true,
 		"noUncheckedIndexedAccess": true,
 		"noUnusedLocals": false, // May want to enable but we let typescript-eslint handle checking this since it can be more granular
+		"paths": {
+			// Electron sets up the submodule type definitions in its main types file
+			"electron/*": ["./node_modules/electron"]
+		},
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"strict": true,


### PR DESCRIPTION
This fixes a couple of issues related to working with Electron types:

1. The `preload` tsconfig used to define the `types` field. Usually you don't want to specify this as it means you override TypeScript's default types resolution behavior (unless you explicitly copy it into your definition). I initially was okay with this because I thought that preload scripts can't access npm-installed dependencies anyways, [but it turns out they can](https://www.electronjs.org/docs/latest/tutorial/tutorial-preload#what-is-a-preload-script)! (emphasis mine)

> On top of [Electron modules](https://www.electronjs.org/docs/latest/api/app), you can also access [Node.js built-ins](https://nodejs.org/dist/latest/docs/api/), _**as well as any packages installed via npm**_.

This will enable the potential usage of npm-installed modules, which hasn't been a huge need yet but I can imagine will be useful down the road.

2. Electron provides conditional exports that allows scoped imports based on the various process environments (i.e. renderer, main, utility processes, etc). This wasn't working in the `preloads` directory due to (1), but fixing that didn't fully make `require('electron/renderer')` work in the preload. In order to fully fix this, the base tsconfig is updated to map electron conditional exports to the types defined by electron's top-level types definition file, which contains the various submodule type definitions.