### PR TITLE
chore: update node version to 22.17.1

### DIFF
--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: .nvmrc
 
       - name: Parse version
         id: version

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,3 +1,3 @@
 # We keep this aligned with the Node version that comes with Electron
 
-22.16.0
+22.17.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 # We keep this aligned with the Node version that comes with Electron
 
-nodejs 22.16.0
+nodejs 22.17.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Go to the [Development](./docs/DEVELOPMENT.md) docs to learn about how the proje
 
 Make sure you have the preferred versions of tooling installed:
 
-- [`NodeJS`](https://nodejs.org): [22.16.0](./.nvmrc)
+- [`NodeJS`](https://nodejs.org): [22.17.1](./.nvmrc)
 
 1. Clone the repo:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
 				"@turf/random": "7.2.0",
 				"@types/geojson": "7946.0.16",
 				"@types/lint-staged": "13.3.0",
-				"@types/node": "22.16.5",
+				"@types/node": "22.17.0",
 				"@types/react": "19.1.9",
 				"@types/react-dom": "19.1.7",
 				"@types/semver": "7.7.0",
@@ -5967,9 +5967,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "22.16.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
-			"integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
+			"version": "22.17.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
+			"integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
 		"@turf/random": "7.2.0",
 		"@types/geojson": "7946.0.16",
 		"@types/lint-staged": "13.3.0",
-		"@types/node": "22.16.5",
+		"@types/node": "22.17.0",
 		"@types/react": "19.1.9",
 		"@types/react-dom": "19.1.7",
 		"@types/semver": "7.7.0",


### PR DESCRIPTION
Fell a bit behind the version that's used by Electron. Really should create a workflow check to catch this (will create an issue shortly)