### PR TITLE
fix: fix issues with rendering mapbox-related map styles

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,5 @@
-ONLINE_STYLE_URL=<value> # URL pointing to an online map's StyleJSON.
-
+ONLINE_STYLE_URL=<value> # URL pointing to an online map's StyleJSON. If it's a Mapbox style, it is preferable to omit the `access_token` search param and specify `VITE_MAPBOX_ACCESS_TOKEN` instead.
+VITE_MAPBOX_ACCESS_TOKEN=<value> # Access token used by map library to make requests to Mapbox
 # APP_TYPE=<value> # Specifies the kind of application (can be `development`, `internal`, `release-candidate`, or `production`)
 # ASAR=<value> # Determines if the ASAR format is used when packaging the app. Must literally be true or false.
 # VITE_FEATURE_TEST_DATA_UI=<value> # Enables the test data UI in the app, which allows creating fake data to use (useful if you need data in development or QA). Set to `true` or `false`.

--- a/.github/workflows/create-builds.yml
+++ b/.github/workflows/create-builds.yml
@@ -85,6 +85,7 @@ jobs:
           APP_TYPE: ${{ inputs.app_type }}
           ONLINE_STYLE_URL: ${{ secrets.ONLINE_STYLE_URL }}
           VITE_FEATURE_TEST_DATA_UI: ${{ env.APP_TYPE == 'production' && 'false' || 'true' }}
+          VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
         run: npm run forge:make
 
       - name: Upload artifacts

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -47,7 +47,8 @@ Make sure you have the desired Node version installed. For this project we encou
 
 Create a copy of the [`.env.template`](../.env.template) and call it `.env`. Update the following variables:
 
-- `ONLINE_STYLE_URL`: Full URL that points to a compatible map's StyleJSON.
+- `ONLINE_STYLE_URL`: Full URL that points to a compatible map's StyleJSON. If it's a Mapbox style, it is preferable to omit the `access_token` search param and specify `VITE_MAPBOX_ACCESS_TOKEN` instead.
+- `VITE_MAPBOX_ACCESS_TOKEN`: Public token necessary used for accessing Mapbox-provided maps. Follow the instructions [here](https://docs.mapbox.com/help/getting-started/access-tokens/) or reach out to the maintainers to obtain one.
 
 ### Running the app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@comapeo/core": "4.1.4",
+				"@comapeo/fallback-smp": "1.0.0",
 				"@comapeo/ipc": "5.0.0",
 				"@formatjs/intl": "3.1.6",
 				"@mapeo/default-config": "5.0.0",
@@ -78,6 +79,7 @@
 				"jsdom": "26.1.0",
 				"lint-staged": "16.1.5",
 				"maplibre-gl": "5.6.2",
+				"maplibregl-mapbox-request-transformer": "0.0.2",
 				"network-information-types": "0.1.1",
 				"npm-run-all2": "8.0.4",
 				"patch-package": "8.0.0",
@@ -13481,6 +13483,13 @@
 			"funding": {
 				"url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
 			}
+		},
+		"node_modules/maplibregl-mapbox-request-transformer": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/maplibregl-mapbox-request-transformer/-/maplibregl-mapbox-request-transformer-0.0.2.tgz",
+			"integrity": "sha512-P4QLyebbrtfAxwYX5ThKRDn2FT77CFxjQ9a5HtmP9l4s3ddwyjD6cpNjwYf2Hl9OApnD7yP3IpdrCCn0S9fI0g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/matcher": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 	},
 	"dependencies": {
 		"@comapeo/core": "4.1.4",
+		"@comapeo/fallback-smp": "1.0.0",
 		"@comapeo/ipc": "5.0.0",
 		"@formatjs/intl": "3.1.6",
 		"@mapeo/default-config": "5.0.0",
@@ -122,6 +123,7 @@
 		"jsdom": "26.1.0",
 		"lint-staged": "16.1.5",
 		"maplibre-gl": "5.6.2",
+		"maplibregl-mapbox-request-transformer": "0.0.2",
 		"network-information-types": "0.1.1",
 		"npm-run-all2": "8.0.4",
 		"patch-package": "8.0.0",

--- a/patches/README.md
+++ b/patches/README.md
@@ -8,3 +8,9 @@ fixes.
 ### [Do not watch fallback map patch when setting up SMP server plugin](./@comapeo+core+4.1.4+001+fix-smp-fallback-map-setup.patch)
 
 By default, core sets up a file watcher for the `fallbackMapPath` option that's provided when instantiating `MapeoManager`. This does not work when packaging the app as an ASAR file (via Electron Forge) because watching a file within the ASAR directory is not possible. Instead, we change the setup so that it does not try to watch the file and instead make the assumption that the file always exists on instantiation, which is generally the case in CoMapeo Desktop (for now).
+
+## styled-map-package
+
+### [Fix CORS issue when serving fallback map when in development](styled-map-package+3.0.0+001+fix-CORS-issue-in-development.patch)
+
+The default fallback offline map fails to load the app due to CORS issue in development. This is because the app is technically being served from a development server in development, which thus has a different origin than the map server that the map is being served from.

--- a/patches/styled-map-package+3.0.0+001+fix-CORS-issue-in-development.patch
+++ b/patches/styled-map-package+3.0.0+001+fix-CORS-issue-in-development.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/styled-map-package/dist/server.js b/node_modules/styled-map-package/dist/server.js
+index 377124f..dce27a7 100644
+--- a/node_modules/styled-map-package/dist/server.js
++++ b/node_modules/styled-map-package/dist/server.js
+@@ -14,10 +14,14 @@ function createServer(fastify, opts, done) {
+   if (!("reader" in opts)) {
+     fastify.addHook("onClose", () => reader.close().catch(noop));
+   }
+-  fastify.get("/style.json", async () => {
++  fastify.get("/style.json", async (_req, reply) => {
+     try {
+       const baseUrl = new URL(fastify.prefix, fastify.listeningOrigin);
+       const style = await reader.getStyle(baseUrl.href);
++      // NOTE: Fixes CORS issues while working in development
++      if (process.env.NODE_ENV === 'development') {
++        reply.headers({ 'access-control-allow-origin': '*' })
++      }
+       return style;
+     } catch (error) {
+       if (isFileNotThereError(error)) {

--- a/src/renderer/src/components/map.tsx
+++ b/src/renderer/src/components/map.tsx
@@ -1,4 +1,9 @@
-import type { Ref } from 'react'
+import { type Ref } from 'react'
+import type { ResourceType } from 'maplibre-gl'
+import {
+	isMapboxURL,
+	transformMapboxUrl,
+} from 'maplibregl-mapbox-request-transformer'
 import {
 	Map as ReactMapLibre,
 	type MapProps,
@@ -7,25 +12,23 @@ import {
 
 import 'maplibre-gl/dist/maplibre-gl.css'
 
-// TODO: Temporary. Need to fix https://github.com/digidem/comapeo-desktop/issues/98
-const FALLBACK_MAP_STYLE = 'https://demotiles.maplibre.org/style.json'
-
 export function Map({
 	doubleClickZoom,
 	dragPan,
 	dragRotate,
 	interactive = true,
-	mapStyle = FALLBACK_MAP_STYLE,
+	mapStyle,
 	ref,
 	reuseMaps = true,
 	scrollZoom,
 	touchPitch,
 	touchZoomRotate,
 	...rest
-}: MapProps & { ref?: Ref<MapRef> }) {
+}: Omit<MapProps, 'transformRequest'> & { ref?: Ref<MapRef> }) {
 	return (
 		<ReactMapLibre
 			{...rest}
+			transformRequest={transformRequest}
 			ref={ref}
 			mapStyle={mapStyle}
 			reuseMaps={reuseMaps}
@@ -47,4 +50,16 @@ export function Map({
 			}
 		/>
 	)
+}
+
+function transformRequest(url: string, resourceType?: ResourceType) {
+	if (isMapboxURL(url)) {
+		return transformMapboxUrl(
+			url,
+			resourceType || '',
+			import.meta.env.VITE_MAPBOX_ACCESS_TOKEN || '',
+		)
+	}
+
+	return { url }
 }

--- a/src/renderer/src/routes/app/projects/$projectId/-displayed-data/map.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/-displayed-data/map.tsx
@@ -9,6 +9,7 @@ import {
 import {
 	useIconUrl,
 	useManyDocs,
+	useMapStyleUrl,
 	useSingleDocByDocId,
 } from '@comapeo/core-react'
 import type { Observation, Preset, Track } from '@comapeo/schema'
@@ -133,6 +134,8 @@ export function DisplayedDataMap() {
 		docType: 'preset',
 		lang,
 	})
+
+	const { data: mapStyleUrl } = useMapStyleUrl()
 
 	const observationsFeatureCollection = useMemo(() => {
 		return observationsToFeatureCollection(observations, categories)
@@ -377,6 +380,7 @@ export function DisplayedDataMap() {
 			)}
 			<Map
 				ref={mapRef}
+				mapStyle={mapStyleUrl}
 				initialViewState={{
 					bounds: observationsBbox,
 					fitBoundsOptions: BASE_FIT_BOUNDS_OPTIONS,

--- a/src/renderer/src/routes/app/projects/$projectId/route.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/route.tsx
@@ -43,6 +43,7 @@ export const Route = createFileRoute('/app/projects/$projectId')({
 	// Accounts for queries used by the MapWithData component.
 	loader: async ({ context, params }) => {
 		const {
+			clientApi,
 			projectApi,
 			queryClient,
 			localeState: { value: lang },
@@ -50,6 +51,12 @@ export const Route = createFileRoute('/app/projects/$projectId')({
 		const { projectId } = params
 
 		await Promise.all([
+			queryClient.ensureQueryData({
+				queryKey: [COMAPEO_CORE_REACT_ROOT_QUERY_KEY, 'maps', 'stylejson_url'],
+				queryFn: async () => {
+					return clientApi.getMapStyleJsonUrl()
+				},
+			}),
 			// TODO: Not ideal but requires changes in @comapeo/core-react
 			queryClient.ensureQueryData({
 				queryKey: [

--- a/src/renderer/vite-env.d.ts
+++ b/src/renderer/vite-env.d.ts
@@ -7,7 +7,8 @@ declare const __APP_TYPE__:
 	| 'production'
 
 interface ImportMetaEnv {
-	readonly VITE_FEATURE_TEST_DATA_UI: string
+	readonly VITE_FEATURE_TEST_DATA_UI?: string
+	readonly VITE_MAPBOX_ACCESS_TOKEN?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Fixes #98 

Also fixes the issue of the offline fallback map not rendering at all.

Requires updating the `ONLINE_STYLE_URL` repo secret and adding a `VITE_MAPBOX_ACCESS_TOKEN` secret, both of which I'll do after this is merged.

---

Preview:

- Online default:

    <img width="600" height="1096" alt="image" src="https://github.com/user-attachments/assets/35db7f2b-0ea5-437c-8dce-730a67b75b5c" />

- Offline default:

    <img width="600" height="1096" alt="image" src="https://github.com/user-attachments/assets/1e2a6322-084e-4315-8c03-502f859340d8" />
