### PR TITLE
feat: implement custom title bar

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -27,6 +27,10 @@
     "description": "Label for stack trace section",
     "message": "Stack trace"
   },
+  "routes.__root.appName": {
+    "description": "Name of the app displayed in the title bar.",
+    "message": "<b><orange>Co</orange>Mapeo</b> <blue>Desktop</blue>"
+  },
   "routes.app.about.title": {
     "message": "About CoMapeo"
   },

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -164,6 +164,8 @@ function initMainWindow({ appVersion, isDevelopment, services }) {
 		minHeight: 500,
 		show: false,
 		backgroundColor: '#050F77',
+		titleBarStyle: 'hiddenInset',
+		titleBarOverlay: true,
 		webPreferences: {
 			preload: MAIN_WINDOW_PRELOAD_PATH,
 			additionalArguments: [`--comapeo-app-version=${appVersion}`],

--- a/src/preload/main-window.js
+++ b/src/preload/main-window.js
@@ -33,7 +33,7 @@ const runtimeApi = {
 		const appVersion = getAppVersion()
 		const systemVersion = process.getSystemVersion()
 
-		return { appVersion, systemVersion }
+		return { appVersion, systemVersion, platform: process.platform }
 	},
 	getWifiConnections: async () => {
 		return ipcRenderer.invoke('system:get:wifiConnections')

--- a/src/preload/runtime.ts
+++ b/src/preload/runtime.ts
@@ -18,7 +18,11 @@ export type RuntimeApi = {
 	) => Promise<SelectedFile | undefined>
 
 	// System
-	getAppInfo: () => { appVersion: string; systemVersion: string }
+	getAppInfo: () => {
+		appVersion: string
+		systemVersion: string
+		platform: NodeJS.Platform
+	}
 	getWifiConnections: () => Promise<Array<Systeminformation.WifiConnectionData>>
 
 	// Shell

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -1,7 +1,9 @@
 import type { MapeoClientApi } from '@comapeo/ipc/client.js'
 import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
 import type { QueryClient } from '@tanstack/react-query'
 import { Outlet, createRootRouteWithContext } from '@tanstack/react-router'
+import { defineMessages, useIntl } from 'react-intl'
 
 import type { LocaleState } from '../../../shared/intl'
 
@@ -12,10 +14,54 @@ export interface RootRouterContext {
 	queryClient: QueryClient
 }
 
+const { platform } = window.runtime.getAppInfo()
+
+const TITLE_BAR_COLOR = '#2348B2'
+// NOTE: This is provided by Electron when using the `titleBarOverlay` option for creating a BrowserWindow
+// - https://www.electronjs.org/docs/latest/api/structures/base-window-options
+// - https://github.com/WICG/window-controls-overlay/blob/main/explainer.md#css-environment-variables
+const TITLE_BAR_HEIGHT = `env(titlebar-area-height)`
+const MAIN_CONTENT_HEIGHT = `calc(100% - ${TITLE_BAR_HEIGHT})`
+
 export const Route = createRootRouteWithContext<RootRouterContext>()({
-	component: () => (
+	component: RouteComponent,
+})
+
+function RouteComponent() {
+	return (
 		<Box height="100dvh">
-			<Outlet />
+			<TitleBar />
+
+			<Box height={MAIN_CONTENT_HEIGHT}>
+				<Outlet />
+			</Box>
 		</Box>
-	),
+	)
+}
+
+function TitleBar() {
+	const { formatMessage: t } = useIntl()
+
+	return (
+		<Box
+			height={TITLE_BAR_HEIGHT}
+			display="flex"
+			alignItems="center"
+			// NOTE: macOS has the window controls on the left side by default.
+			justifyContent={platform === 'darwin' ? 'flex-end' : undefined}
+			paddingX={6}
+			bgcolor={TITLE_BAR_COLOR}
+			sx={{ appRegion: 'drag', '-webkit-app-region': 'drag' }}
+		>
+			<Typography color="textInverted">{t(m.appName)}</Typography>
+		</Box>
+	)
+}
+
+const m = defineMessages({
+	appName: {
+		id: 'routes.__root.appName',
+		defaultMessage: '<b><orange>Co</orange>Mapeo</b> <blue>Desktop</blue>',
+		description: 'Name of the app displayed in the title bar.',
+	},
 })


### PR DESCRIPTION
Closes #209 

Might need some follow-ups based on what it looks like on Windows and Linux.

---

Preview:

- macOS:

    <img width="600" height="1095" alt="image" src="https://github.com/user-attachments/assets/e7555b6a-0654-4922-ae71-96554b1ec489" />

    <img width="600" height="1097" alt="image" src="https://github.com/user-attachments/assets/f1781ef0-c3c7-4026-b684-63b6095f2468" />
    
    - Ensuring overlays work as expected (e.g. error dialog, alerts):
    
        <img width="600" height="1094" alt="image" src="https://github.com/user-attachments/assets/2c646def-82bd-49ac-abcb-1fcfa506cb19" />
        
        <img width="600" height="1098" alt="image" src="https://github.com/user-attachments/assets/89440439-a4a9-4d6a-b144-421953274ecb" />

