### PR TITLE
chore: fix warning about invalid css property name

### DIFF
--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -51,7 +51,7 @@ function TitleBar() {
 			justifyContent={platform === 'darwin' ? 'flex-end' : undefined}
 			paddingX={6}
 			bgcolor={TITLE_BAR_COLOR}
-			sx={{ appRegion: 'drag', '-webkit-app-region': 'drag' }}
+			sx={{ appRegion: 'drag', WebkitAppRegion: 'drag' }}
 		>
 			<Typography color="textInverted">{t(m.appName)}</Typography>
 		</Box>


### PR DESCRIPTION
Follow-up to #211 . Didn't notice the warning that was being logged due to an incorrectly named css property.