### PR TITLE
fix: ensure form field labels render underneath action buttons

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId_/settings/info.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/settings/info.tsx
@@ -416,6 +416,7 @@ function RouteComponent() {
 						position="sticky"
 						bottom={0}
 						alignItems="center"
+						zIndex={1}
 					>
 						<form.Subscribe
 							selector={(state) => [state.canSubmit, state.isSubmitting]}

--- a/src/renderer/src/routes/app/settings/device-name.tsx
+++ b/src/renderer/src/routes/app/settings/device-name.tsx
@@ -194,6 +194,7 @@ function RouteComponent() {
 						position="sticky"
 						bottom={0}
 						alignItems="center"
+						zIndex={1}
 					>
 						<form.Subscribe
 							selector={(state) => [state.canSubmit, state.isSubmitting]}

--- a/src/renderer/src/routes/app/settings_/test-data.tsx
+++ b/src/renderer/src/routes/app/settings_/test-data.tsx
@@ -407,6 +407,7 @@ function RouteComponent() {
 								position="sticky"
 								bottom={0}
 								alignItems="center"
+								zIndex={1}
 							>
 								<form.Subscribe
 									selector={(state) =>


### PR DESCRIPTION
Was only an existing issue on the test data creation page, but updated other similar pages to avoid potential issues later on.

---

Preview:

- Before

    <img width="600" height="283" alt="image" src="https://github.com/user-attachments/assets/811649df-ae35-4c46-85a0-bfe8efacb431" />


- After:

    <img width="600" height="278" alt="image" src="https://github.com/user-attachments/assets/a00463b4-8997-49bb-bb8b-3e194f98ebbc" />
