### PR TITLE
fix: various fixes for joining a project in onboarding

### DIFF
--- a/src/renderer/src/routes/onboarding/-shared/queries.ts
+++ b/src/renderer/src/routes/onboarding/-shared/queries.ts
@@ -3,7 +3,7 @@ import {
 	useCreateProject,
 	useRejectInvite,
 } from '@comapeo/core-react'
-import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 
 export const ONBOARDING_ACCEPT_INVITE_MUTATION_KEY = [
 	'invites',
@@ -15,31 +15,21 @@ export const ONBOARDING_REJECT_INVITE_MUTATION_KEY = [
 	'reject',
 ] as const
 
-export function useOnboardingAcceptInvite(
-	opts?: UseMutationOptions<string, Error, { inviteId: string }>,
-) {
-	const { mutateAsync } = useAcceptInvite()
+export function useOnboardingRejectInvite() {
+	const rejectInvite = useRejectInvite()
 
 	return useMutation({
-		...opts,
-		mutationKey: ONBOARDING_ACCEPT_INVITE_MUTATION_KEY,
-		mutationFn: async ({ inviteId }) => {
-			return mutateAsync({ inviteId })
-		},
+		mutationKey: ONBOARDING_REJECT_INVITE_MUTATION_KEY,
+		mutationFn: rejectInvite.mutateAsync,
 	})
 }
 
-export function useOnboardingRejectInvite(
-	opts?: UseMutationOptions<void, Error, { inviteId: string }>,
-) {
-	const { mutateAsync } = useRejectInvite()
+export function useOnboardingAcceptInvite() {
+	const acceptInvite = useAcceptInvite()
 
 	return useMutation({
-		...opts,
-		mutationKey: ONBOARDING_REJECT_INVITE_MUTATION_KEY,
-		mutationFn: async ({ inviteId }) => {
-			return mutateAsync({ inviteId })
-		},
+		mutationKey: ONBOARDING_ACCEPT_INVITE_MUTATION_KEY,
+		mutationFn: acceptInvite.mutateAsync,
 	})
 }
 
@@ -48,19 +38,18 @@ export const ONBOARDING_CREATE_PROJECT_MUTATION_KEY = [
 	'create',
 ] as const
 
-export function useOnboardingCreateProject(
-	opts?: UseMutationOptions<
-		string,
-		Error,
-		{ name?: string; configPath?: string }
-	>,
-) {
+export function useOnboardingCreateProject() {
 	const { mutateAsync } = useCreateProject()
 
 	return useMutation({
-		...opts,
 		mutationKey: ONBOARDING_CREATE_PROJECT_MUTATION_KEY,
-		mutationFn: async ({ name, configPath }) => {
+		mutationFn: async ({
+			name,
+			configPath,
+		}: {
+			name?: string
+			configPath?: string
+		}) => {
 			return mutateAsync({ name, configPath })
 		},
 	})

--- a/src/renderer/src/routes/onboarding/project/index.tsx
+++ b/src/renderer/src/routes/onboarding/project/index.tsx
@@ -7,9 +7,11 @@ import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
+import { useIsMutating } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { defineMessages, useIntl } from 'react-intl'
 
+import { ONBOARDING_REJECT_INVITE_MUTATION_KEY } from '../-shared/queries'
 import {
 	BLUE_GREY,
 	DARKER_ORANGE,
@@ -39,10 +41,18 @@ function RouteComponent() {
 	const { formatMessage: t } = useIntl()
 
 	const navigate = useNavigate()
-	const { data: invites } = useManyInvites()
+
+	const { data: invites, isRefetching: isRefetchingInvites } = useManyInvites()
+
+	const rejectingInvite =
+		useIsMutating({ mutationKey: ONBOARDING_REJECT_INVITE_MUTATION_KEY }) > 0
 
 	useEffect(() => {
-		const pendingInvite = invites.find((i) => i.state === 'pending')
+		if (rejectingInvite || isRefetchingInvites) {
+			return
+		}
+
+		const pendingInvite = invites.find((invite) => invite.state === 'pending')
 
 		if (pendingInvite) {
 			navigate({
@@ -50,7 +60,7 @@ function RouteComponent() {
 				params: { inviteId: pendingInvite.inviteId },
 			})
 		}
-	}, [invites, navigate])
+	}, [invites, navigate, rejectingInvite, isRefetchingInvites])
 
 	return (
 		<Stack

--- a/src/renderer/src/routes/onboarding/route.tsx
+++ b/src/renderer/src/routes/onboarding/route.tsx
@@ -5,7 +5,7 @@ import Divider from '@mui/material/Divider'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { captureException } from '@sentry/react'
-import { useMutationState } from '@tanstack/react-query'
+import { useIsMutating } from '@tanstack/react-query'
 import {
 	Outlet,
 	createFileRoute,
@@ -44,37 +44,17 @@ function RouteComponent() {
 
 	const rejectInvite = useOnboardingRejectInvite()
 
-	const acceptInviteStatus = useMutationState({
-		filters: {
-			mutationKey: ONBOARDING_ACCEPT_INVITE_MUTATION_KEY,
-		},
-		select: (mutation) => {
-			return mutation.state.status
-		},
-	})
+	const isAcceptingInvite =
+		useIsMutating({ mutationKey: ONBOARDING_ACCEPT_INVITE_MUTATION_KEY }) > 0
 
-	const rejectInviteStatus = useMutationState({
-		filters: {
-			mutationKey: ONBOARDING_REJECT_INVITE_MUTATION_KEY,
-		},
-		select: (mutation) => {
-			return mutation.state.status
-		},
-	})
+	const isRejectingInvite =
+		useIsMutating({ mutationKey: ONBOARDING_REJECT_INVITE_MUTATION_KEY }) > 0
 
-	const createProjectStatus = useMutationState({
-		filters: {
-			mutationKey: ONBOARDING_CREATE_PROJECT_MUTATION_KEY,
-		},
-		select: (mutation) => {
-			return mutation.state.status
-		},
-	})
+	const isCreatingProject =
+		useIsMutating({ mutationKey: ONBOARDING_CREATE_PROJECT_MUTATION_KEY }) > 0
 
 	const importantMutationInProgress =
-		rejectInviteStatus.some((s) => s === 'pending') ||
-		acceptInviteStatus.some((s) => s === 'pending') ||
-		createProjectStatus.some((s) => s === 'pending')
+		isAcceptingInvite || isRejectingInvite || isCreatingProject
 
 	const shouldHideBackButton =
 		currentPath === '/onboarding/project/create/$projectId/success' ||
@@ -105,8 +85,8 @@ function RouteComponent() {
 
 								// TODO: There's probably a better way of doing this...
 								if (
-									currentRouteMatch.fullPath ===
-									'/onboarding/project/join/$inviteId'
+									currentRouteMatch.routeId ===
+									'/onboarding/project/join/$inviteId/'
 								) {
 									// TODO: Should we block navigation if this fails?
 									rejectInvite.mutate(


### PR DESCRIPTION
#221 has enabled being able to actually test the project joining flow. Discovered quite a number of bugs as a result of being able to receive invites from mobile:

- fixes an issue with redirection logic after rejecting an invite
- fixes issue where invite cancellation does not trigger redirect
- addresses edge case of navigating to project invite page for an invite that cannot be responded to
- fixes issue where back button does not reject invite automatically

---

Preview (assumes that #221 is eventually merged):

https://github.com/user-attachments/assets/d7a4d343-844f-4bb8-aeaa-d0a29be9bd9e

