### PR TITLE
feat: allow creation of track in test data creation page

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -517,6 +517,10 @@
     "description": "Label for create button.",
     "message": "Create"
   },
+  "routes.app.settings_.test-data.createTrack": {
+    "description": "Label for toggle to create track when creating test data.",
+    "message": "Create track"
+  },
   "routes.app.settings_.test-data.invalidBoundedDistanceFormat": {
     "description": "Error message for when bounded distance is not an decimal.",
     "message": "Must be a decimal"
@@ -550,12 +554,16 @@
     "message": "Number of observations"
   },
   "routes.app.settings_.test-data.observationCreateSuccess": {
-    "description": "Message displayed when observation creation succeeds",
-    "message": "Created {count} observations."
+    "description": "Message displayed when observation creation succeeds.",
+    "message": "Created {count, plural, one {# observation} other {# observations}}."
   },
   "routes.app.settings_.test-data.requiredError": {
     "description": "Error message for when required input is empty.",
     "message": "Required"
+  },
+  "routes.app.settings_.test-data.trackCreateSuccess": {
+    "description": "Message displayed when track creation succeeds.",
+    "message": "Created {count, plural, one {# track} other {# tracks}}."
   },
   "routes.onboarding.data-and-privacy.dataEncrypted": {
     "message": "All data stays fully encrypted."

--- a/src/renderer/src/components/error-dialog.tsx
+++ b/src/renderer/src/components/error-dialog.tsx
@@ -12,15 +12,13 @@ import { defineMessages, useIntl } from 'react-intl'
 import { BLUE_GREY, DARK_GREY, LIGHT_GREY } from '../colors'
 import { Icon } from './icon'
 
-export function ErrorDialog({
-	errorMessage,
-	onClose,
-	open,
-}: {
+export type Props = {
 	errorMessage?: string
 	onClose: MouseEventHandler<HTMLButtonElement>
 	open: boolean
-}) {
+}
+
+export function ErrorDialog({ errorMessage, onClose, open }: Props) {
 	const { formatMessage: t } = useIntl()
 
 	const [advancedExpanded, setAdvancedExpanded] = useState(false)


### PR DESCRIPTION
Towards #161

Adds a toggle in the test creation page to enable creating a track that uses the observations created as its reference. We don't try to do anything super smart in terms of generating realistic location points for the track, and instead just use the observations' coordinates as the track's recorded locations.

---

Preview:

<img width="600" height="1096" alt="image" src="https://github.com/user-attachments/assets/cb3bbea0-4161-4a0b-841e-35898674cb0a" />


