### PR TITLE
chore: specify notes tag when creating test track

### DIFF
--- a/src/renderer/src/routes/app/settings_/test-data.tsx
+++ b/src/renderer/src/routes/app/settings_/test-data.tsx
@@ -680,6 +680,8 @@ function useCreateTestObservations({ projectId }: { projectId: string }) {
 function useCreateTestTrack({ projectId }: { projectId: string }) {
 	const queryClient = useQueryClient()
 
+	const { data: deviceInfo } = useOwnDeviceInfo()
+
 	const { data: presets } = useManyDocs({ projectId, docType: 'preset' })
 
 	const createTrack = useCreateDocument({
@@ -717,19 +719,21 @@ function useCreateTestTrack({ projectId }: { projectId: string }) {
 				}
 			}
 
+			const notes = deviceInfo.name ? `Created by ${deviceInfo.name}` : null
+
 			return createTrack.mutateAsync({
 				value: {
 					locations,
 					observationRefs,
 					...(randomPreset
 						? {
-								tags: randomPreset.tags,
+								tags: { ...randomPreset.tags, notes },
 								presetRef: {
 									docId: randomPreset.docId,
 									versionId: randomPreset.versionId,
 								},
 							}
-						: { tags: {} }),
+						: { tags: { notes } }),
 				},
 			})
 		},


### PR DESCRIPTION
Towards #147 

Useful to have something inserted as a description of the track, similar to what we do for test observation creation.