### PR TITLE
fix: fix overflow within list item

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId/-displayed-data/list.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/-displayed-data/list.tsx
@@ -50,7 +50,9 @@ import {
 import { getLocaleStateQueryOptions } from '../../../../../lib/queries/app-settings'
 
 const CATEGORY_CONTAINER_SIZE_PX = 64
-const APPROXIMATE_ITEM_HEIGHT_PX = CATEGORY_CONTAINER_SIZE_PX + 16 * 2
+
+// NOTE: Accounts for space added by top + bottom padding and bottom border
+const APPROXIMATE_ITEM_HEIGHT_PX = CATEGORY_CONTAINER_SIZE_PX + 16 * 2 + 1
 
 export function DisplayedDataList({ projectId }: { projectId: string }) {
 	const { formatMessage: t, formatDate } = useIntl()


### PR DESCRIPTION
The virtual list size calculation didn't account for the 1px added due to a bottom border on each item. This sometimes caused a vertical overflow within the list item (which thus shows the scrollbar unintentionally).