### PR TITLE
fix: fix rendering of category icon image when image fails to load

### DIFF
--- a/src/renderer/src/components/category-icon.tsx
+++ b/src/renderer/src/components/category-icon.tsx
@@ -67,7 +67,17 @@ export function CategoryIconImage({
 	return (
 		<ErrorBoundary
 			getResetKey={() => iconUrl}
-			fallback={() => <Icon name="material-error" color="error" />}
+			fallback={() => (
+				<Box
+					sx={imageStyle}
+					display="flex"
+					justifyContent="center"
+					alignItems="center"
+					flex={1}
+				>
+					<Icon name="material-error" color="error" />
+				</Box>
+			)}
 		>
 			<Suspense fallback={<CircularProgress disableShrink />}>
 				<SuspenseImage src={iconUrl} alt={altText} style={imageStyle} />


### PR DESCRIPTION
Introduced this issue in #230 🤦 

---

Preview:

- Before:

  <img width="600" height="1096" alt="image" src="https://github.com/user-attachments/assets/88e7ddb4-7c72-42e0-9977-d55f3a2680ca" />

- After:

  <img width="600" height="1096" alt="image" src="https://github.com/user-attachments/assets/06d84285-1881-4ece-a9d7-4838998a98a5" />
