### PR TITLE
chore: app initilalization improvements

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -1,4 +1,8 @@
 {
+  "components.app-title-bar.appName": {
+    "description": "Name of the app displayed in the title bar.",
+    "message": "<b><orange>Co</orange>Mapeo</b> <blue>Desktop</blue>"
+  },
   "components.error-dialog.advanced": {
     "description": "Title text for the collapsible section that shows the actual error message.",
     "message": "Advanced"
@@ -26,10 +30,6 @@
   "components.generic-route-error-component.stacktrace": {
     "description": "Label for stack trace section",
     "message": "Stack trace"
-  },
-  "routes.__root.appName": {
-    "description": "Name of the app displayed in the title bar.",
-    "message": "<b><orange>Co</orange>Mapeo</b> <blue>Desktop</blue>"
   },
   "routes.app.about.title": {
     "message": "About CoMapeo"

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -181,9 +181,11 @@ export async function start({ appConfig, configStore }) {
 		},
 	})
 
-	mainWindow.show()
-
 	log(`Created main window with id ${mainWindow.id}`)
+
+	mainWindow.addListener('ready-to-show', () => {
+		mainWindow.show()
+	})
 }
 
 /**

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -25,6 +25,7 @@ import {
 
 import type { LocaleState } from '../../shared/intl'
 import { initComapeoClient } from './comapeo-client'
+import { AppTitleBar, TITLE_BAR_HEIGHT } from './components/app-title-bar'
 import { GenericRouteErrorComponent } from './components/generic-route-error-component'
 import { GenericRoutePendingComponent } from './components/generic-route-pending-component'
 import { IntlProvider } from './contexts/intl'
@@ -101,41 +102,52 @@ initSentryElectron(
 	initSentryReact,
 )
 
+const { platform } = window.runtime.getAppInfo()
+
+const MAIN_CONTENT_HEIGHT = `calc(100% - ${TITLE_BAR_HEIGHT})`
+
 export function App() {
 	return (
 		<StrictMode>
 			<ThemeProvider theme={theme}>
 				<CssBaseline enableColorScheme />
-				<QueryClientProvider client={queryClient}>
-					<NetworkConnectionChangeListener />
 
-					<Suspense
-						fallback={
-							<Box
-								height="100vh"
-								display="flex"
-								justifyContent="center"
-								alignItems="center"
-							>
-								<CircularProgress />
+				<QueryClientProvider client={queryClient}>
+					<IntlProvider>
+						<NetworkConnectionChangeListener />
+
+						<Box height="100dvh">
+							<AppTitleBar platform={platform} />
+
+							<Box height={MAIN_CONTENT_HEIGHT}>
+								<Suspense
+									fallback={
+										<Box
+											display="flex"
+											justifyContent="center"
+											alignItems="center"
+											height="100%"
+										>
+											<CircularProgress />
+										</Box>
+									}
+								>
+									<ClientApiProvider clientApi={clientApi}>
+										<WithInvitesListener>
+											<WithAddedRouteContext>
+												{({ activeProjectId, localeState }) => (
+													<RouterProvider
+														router={router}
+														context={{ activeProjectId, localeState }}
+													/>
+												)}
+											</WithAddedRouteContext>
+										</WithInvitesListener>
+									</ClientApiProvider>
+								</Suspense>
 							</Box>
-						}
-					>
-						<IntlProvider>
-							<ClientApiProvider clientApi={clientApi}>
-								<WithInvitesListener>
-									<WithAddedRouteContext>
-										{({ activeProjectId, localeState }) => (
-											<RouterProvider
-												router={router}
-												context={{ activeProjectId, localeState }}
-											/>
-										)}
-									</WithAddedRouteContext>
-								</WithInvitesListener>
-							</ClientApiProvider>
-						</IntlProvider>
-					</Suspense>
+						</Box>
+					</IntlProvider>
 				</QueryClientProvider>
 			</ThemeProvider>
 		</StrictMode>

--- a/src/renderer/src/components/app-title-bar.tsx
+++ b/src/renderer/src/components/app-title-bar.tsx
@@ -1,0 +1,37 @@
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { defineMessages, useIntl } from 'react-intl'
+
+const TITLE_BAR_COLOR = '#2348B2'
+
+// NOTE: This is provided by Electron when using the `titleBarOverlay` option for creating a BrowserWindow
+// - https://www.electronjs.org/docs/latest/api/structures/base-window-options
+// - https://github.com/WICG/window-controls-overlay/blob/main/explainer.md#css-environment-variables
+export const TITLE_BAR_HEIGHT = `env(titlebar-area-height)`
+
+export function AppTitleBar({ platform }: { platform: NodeJS.Platform }) {
+	const { formatMessage: t } = useIntl()
+
+	return (
+		<Box
+			height={TITLE_BAR_HEIGHT}
+			display="flex"
+			alignItems="center"
+			// NOTE: macOS has the window controls on the left side by default.
+			justifyContent={platform === 'darwin' ? 'flex-end' : undefined}
+			paddingX={6}
+			bgcolor={TITLE_BAR_COLOR}
+			sx={{ appRegion: 'drag', WebkitAppRegion: 'drag' }}
+		>
+			<Typography color="textInverted">{t(m.appName)}</Typography>
+		</Box>
+	)
+}
+
+const m = defineMessages({
+	appName: {
+		id: 'components.app-title-bar.appName',
+		defaultMessage: '<b><orange>Co</orange>Mapeo</b> <blue>Desktop</blue>',
+		description: 'Name of the app displayed in the title bar.',
+	},
+})

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -3,7 +3,3 @@
 :root {
 	scrollbar-color: #ccccd6 transparent;
 }
-
-body {
-	min-height: 100dvh;
-}

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -1,9 +1,6 @@
 import type { MapeoClientApi } from '@comapeo/ipc/client.js'
-import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
 import type { QueryClient } from '@tanstack/react-query'
 import { Outlet, createRootRouteWithContext } from '@tanstack/react-router'
-import { defineMessages, useIntl } from 'react-intl'
 
 import type { LocaleState } from '../../../shared/intl'
 
@@ -14,54 +11,10 @@ export interface RootRouterContext {
 	queryClient: QueryClient
 }
 
-const { platform } = window.runtime.getAppInfo()
-
-const TITLE_BAR_COLOR = '#2348B2'
-// NOTE: This is provided by Electron when using the `titleBarOverlay` option for creating a BrowserWindow
-// - https://www.electronjs.org/docs/latest/api/structures/base-window-options
-// - https://github.com/WICG/window-controls-overlay/blob/main/explainer.md#css-environment-variables
-const TITLE_BAR_HEIGHT = `env(titlebar-area-height)`
-const MAIN_CONTENT_HEIGHT = `calc(100% - ${TITLE_BAR_HEIGHT})`
-
 export const Route = createRootRouteWithContext<RootRouterContext>()({
 	component: RouteComponent,
 })
 
 function RouteComponent() {
-	return (
-		<Box height="100dvh">
-			<TitleBar />
-
-			<Box height={MAIN_CONTENT_HEIGHT}>
-				<Outlet />
-			</Box>
-		</Box>
-	)
+	return <Outlet />
 }
-
-function TitleBar() {
-	const { formatMessage: t } = useIntl()
-
-	return (
-		<Box
-			height={TITLE_BAR_HEIGHT}
-			display="flex"
-			alignItems="center"
-			// NOTE: macOS has the window controls on the left side by default.
-			justifyContent={platform === 'darwin' ? 'flex-end' : undefined}
-			paddingX={6}
-			bgcolor={TITLE_BAR_COLOR}
-			sx={{ appRegion: 'drag', WebkitAppRegion: 'drag' }}
-		>
-			<Typography color="textInverted">{t(m.appName)}</Typography>
-		</Box>
-	)
-}
-
-const m = defineMessages({
-	appName: {
-		id: 'routes.__root.appName',
-		defaultMessage: '<b><orange>Co</orange>Mapeo</b> <blue>Desktop</blue>',
-		description: 'Name of the app displayed in the title bar.',
-	},
-})


### PR DESCRIPTION
- On startup, shows the window when the 'ready-to-show` event fires, which reduces the visual flashing you see when opening the app. There's probably a slight cost to perceived startup time but it's negligible for now.

- Displays the title bar all the time. Used to only show after the initial loading state