### PR TITLE
chore: update reload handler in generic route error component

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -20,7 +20,7 @@
     "message": "Error"
   },
   "components.generic-route-error-component.reload": {
-    "description": "Button text to reload the page",
+    "description": "Text for button to reload page.",
     "message": "Reload"
   },
   "components.generic-route-error-component.somethinWentWrong": {

--- a/src/renderer/src/components/generic-route-error-component.tsx
+++ b/src/renderer/src/components/generic-route-error-component.tsx
@@ -2,13 +2,13 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
-import { useNavigate, type ErrorComponentProps } from '@tanstack/react-router'
+import { useRouter, type ErrorComponentProps } from '@tanstack/react-router'
 import { defineMessages, useIntl } from 'react-intl'
 
 import { BLUE_GREY, LIGHT_GREY, WHITE } from '../colors'
 
 export function GenericRouteErrorComponent({ error }: ErrorComponentProps) {
-	const navigate = useNavigate()
+	const router = useRouter()
 
 	const { formatMessage: t } = useIntl()
 
@@ -81,12 +81,13 @@ export function GenericRouteErrorComponent({ error }: ErrorComponentProps) {
 				bottom={0}
 				padding={6}
 				display="flex"
-				justifyContent="center"
+				flexDirection="column"
+				alignItems="center"
 			>
 				<Button
 					fullWidth
 					onClick={() => {
-						navigate({ to: '.', reloadDocument: true })
+						router.invalidate()
 					}}
 					sx={{ maxWidth: 400 }}
 				>
@@ -116,6 +117,6 @@ const m = defineMessages({
 	reload: {
 		id: 'components.generic-route-error-component.reload',
 		defaultMessage: 'Reload',
-		description: 'Button text to reload the page',
+		description: 'Text for button to reload page.',
 	},
 })


### PR DESCRIPTION
Updates the reload handling to follow tanstack router's [guidance](https://tanstack.com/router/latest/docs/framework/react/guide/data-loading#handling-errors-with-routeoptionserrorcomponent):

> If the error was the result of a route load, you should instead call router.invalidate(), which will coordinate both a router reload and an error boundary reset: 

Not all errors will be caused by route loading but at least those will be more idiomatically handled now.