### PR TITLE
fix: fix executable name for macOS

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -379,39 +379,50 @@ function getPropertiesForAppType(appType) {
 	const baseExecutableName = 'comapeo-desktop'
 	const baseAppName = packageJSON.productName
 
+	const isMacOS = process.platform === 'darwin'
+
 	switch (appType) {
 		case 'development': {
 			const shortName = 'dev'
+			const appName = `${baseAppName} Dev`
 			return {
 				shortName,
 				appBundleId: `${baseAppBundleId}.${shortName}`,
-				appName: `${baseAppName} Dev`,
-				executableName: `${baseExecutableName}-${shortName}`,
+				appName,
+				executableName: isMacOS
+					? appName
+					: `${baseExecutableName}-${shortName}`,
 			}
 		}
 		case 'internal': {
 			const shortName = 'internal'
+			const appName = `${baseAppName} Internal`
 			return {
 				shortName,
 				appBundleId: `${baseAppBundleId}.${shortName}`,
-				appName: `${baseAppName} Internal`,
-				executableName: `${baseExecutableName}-${shortName}`,
+				appName,
+				executableName: isMacOS
+					? appName
+					: `${baseExecutableName}-${shortName}`,
 			}
 		}
 		case 'release-candidate': {
 			const shortName = 'rc'
+			const appName = `${baseAppName} RC`
 			return {
 				shortName,
 				appBundleId: `${baseAppBundleId}.${shortName}`,
-				appName: `${baseAppName} RC`,
-				executableName: `${baseExecutableName}-${shortName}`,
+				appName,
+				executableName: isMacOS
+					? appName
+					: `${baseExecutableName}-${shortName}`,
 			}
 		}
 		case 'production': {
 			return {
 				appBundleId: baseAppBundleId,
 				appName: baseAppName,
-				executableName: baseExecutableName,
+				executableName: isMacOS ? baseAppName : baseExecutableName,
 			}
 		}
 	}


### PR DESCRIPTION
By convention, the executable name for the application on macOS is usually the same as the application name. However, I thought it would be okay for it to adhere to more conventional posix-naming i.e. lowercase + hyphen-separated. While this generally works, some applications will display the executable name instead of the application name, such as Raycast. On Finder, seems like it'll default to the name of the application directory found in the `Applications` folder, so it's not an issue for that at least. However, to potentially avoid similar cases with other tools, I think it's safer to just follow the convention instead of being more posix-friendly on macOS 😄 

---

Before:

<img width="600" height="155" alt="image" src="https://github.com/user-attachments/assets/01256cae-6373-467e-b909-7cd9baa4acff" />

After:

<img width="600" height="163" alt="image" src="https://github.com/user-attachments/assets/35be4aab-51a3-4d86-9719-a02b27f45e13" />
