### PR TITLE
fix: do not redirect to invitable device list if local peer is disconnected

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId_/invite/devices/$deviceId/route.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/invite/devices/$deviceId/route.tsx
@@ -14,7 +14,7 @@ export const Route = createFileRoute(
 
 		const matchingPeer = peers.find((p) => p.deviceId === deviceId)
 
-		if (!matchingPeer || matchingPeer.status === 'disconnected') {
+		if (!matchingPeer) {
 			throw redirect({
 				to: '/app/projects/$projectId/invite/devices',
 				params: { projectId },


### PR DESCRIPTION
Before, the following sequence would result in being confusedly redirected to the invitable devices list:

1. Desktop: Go to invitable devices list
2. Desktop: Select connected Mobile
3. Mobile: close the app (or force a disconnect somehow)
4. Desktop: Select role

This PR makes a slight adjustment to the loading behavior of the role selection and send pages so that a redirect does not happen just because a local peer has been disconnected.