### PR TITLE
fix: prevent UI flashing when error occurs on sending invite

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId_/invite/devices/$deviceId/send.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/invite/devices/$deviceId/send.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useState } from 'react'
+import { Suspense, useDeferredValue, useEffect, useState } from 'react'
 import {
 	useRequestCancelInvite,
 	useSendInvite,
@@ -110,7 +110,9 @@ function RouteComponent() {
 		[deviceId, cancelInvite, queryClient],
 	)
 
-	if (invite.status === 'idle' || invite.status === 'error') {
+	const deferredInviteStatus = useDeferredValue(invite.status)
+
+	if (deferredInviteStatus === 'idle' || deferredInviteStatus === 'error') {
 		return (
 			<ReviewInvitation
 				error={invite.error}
@@ -128,7 +130,7 @@ function RouteComponent() {
 		)
 	}
 
-	if (invite.status === 'pending') {
+	if (deferredInviteStatus === 'pending') {
 		return (
 			<InvitePending
 				sentAt={invite.submittedAt}


### PR DESCRIPTION
Fixes an issue of flashing content if the attempt to send an invite fails

---

Preview:

- Before:

    https://github.com/user-attachments/assets/92211228-5435-4c70-939a-ab8736a6df43

- After:

    https://github.com/user-attachments/assets/a22bdb35-c379-472b-9b6d-5ba8636ab39b

