### PR TITLE
chore: make ONLINE_STYLE_URL env variable optional

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,13 @@
-ONLINE_STYLE_URL=<value> # URL pointing to an online map's StyleJSON. If it's a Mapbox style, it is preferable to omit the `access_token` search param and specify `VITE_MAPBOX_ACCESS_TOKEN` instead.
+### Sentry
 SENTRY_AUTH_TOKEN=<value> # Auth token for Sentry
-VITE_MAPBOX_ACCESS_TOKEN=<value> # Access token used by map library to make requests to Mapbox
+SENTRY_ORG=<value> # Sentry organization
+SENTRY_PROJECT=<value> # Sentry project name
+
+### Map customization
+# ONLINE_STYLE_URL=<value> # URL pointing to an online map's StyleJSON. If it's a Mapbox style, it is preferable to omit the `access_token` search param and specify `VITE_MAPBOX_ACCESS_TOKEN` instead.
+# VITE_MAPBOX_ACCESS_TOKEN=<value> # Access token used by map library to make requests to Mapbox
+
+### App configuration
 # APP_TYPE=<value> # Specifies the kind of application (can be `development`, `internal`, `release-candidate`, or `production`)
 # ASAR=<value> # Determines if the ASAR format is used when packaging the app. Must literally be true or false.
 # VITE_FEATURE_TEST_DATA_UI=<value> # Enables the test data UI in the app, which allows creating fake data to use (useful if you need data in development or QA). Set to `true` or `false`.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -47,11 +47,14 @@ Make sure you have the desired Node version installed. For this project we encou
 
 Create a copy of the [`.env.template`](../.env.template) and call it `.env`. Update the following variables:
 
-- `ONLINE_STYLE_URL`: Full URL that points to a compatible map's StyleJSON. If it's a Mapbox style, it is preferable to omit the `access_token` search param and specify `VITE_MAPBOX_ACCESS_TOKEN` instead.
 - `SENTRY_AUTH_TOKEN`: Auth token used for enabling Sentry integration. Reach out to the maintainers for setting this up.
 - `SENTRY_ORG`: Organization name on Sentry. Reach out to the maintainers for setting this up.
 - `SENTRY_PROJECT`: Project name on Sentry. Reach out to the maintainers for setting this up.
-- `VITE_MAPBOX_ACCESS_TOKEN`: Public token necessary for accessing Mapbox-provided resources. Follow the instructions [here](https://docs.mapbox.com/help/getting-started/access-tokens/) or reach out to the maintainers to obtain one.
+
+If you're planning to use a different online map style, you'll need to specify a couple of other environment variables:
+
+- `ONLINE_STYLE_URL`: Full URL that points to a compatible map's StyleJSON. If it's a [Mapbox](https://www.mapbox.com/) style, it is preferable to omit the `access_token` search param and specify `VITE_MAPBOX_ACCESS_TOKEN` instead.
+- `VITE_MAPBOX_ACCESS_TOKEN`: Public token necessary for accessing [Mapbox](https://www.mapbox.com/)-provided resources. Follow the instructions [here](https://docs.mapbox.com/help/getting-started/access-tokens/) or reach out to the maintainers to obtain one.
 
 ### Running the app
 

--- a/forge.config.js
+++ b/forge.config.js
@@ -56,7 +56,7 @@ const {
 			),
 			'true',
 		),
-		ONLINE_STYLE_URL: v.pipe(v.string(), v.url()),
+		ONLINE_STYLE_URL: v.optional(v.pipe(v.string(), v.url())),
 		USER_DATA_PATH: v.optional(v.string()),
 		VITE_MAPBOX_ACCESS_TOKEN: v.optional(v.string()),
 	}),
@@ -117,20 +117,25 @@ class CoMapeoDesktopForgePlugin extends PluginBase {
 
 		// Use the `VITE_MAPBOX_ACCESS_TOKEN` to the online style URL
 		// if it's a Mapbox style that doesn't already have an access token param
-		const onlineStyleUrl = new URL(ONLINE_STYLE_URL)
-		if (onlineStyleUrl.host === 'api.mapbox.com') {
-			if (
-				!onlineStyleUrl.searchParams.has('access_token') &&
-				VITE_MAPBOX_ACCESS_TOKEN
-			) {
-				onlineStyleUrl.searchParams.set(
-					'access_token',
-					VITE_MAPBOX_ACCESS_TOKEN,
-				)
-			} else {
-				console.warn(
-					'⚠️ Using a Mapbox map requires an access token. Either update the `ONLINE_STYLE_URL` env variable or specify the `VITE_MAPBOX_ACCESS_TOKEN` env variable',
-				)
+		const onlineStyleUrl = ONLINE_STYLE_URL
+			? new URL(ONLINE_STYLE_URL)
+			: undefined
+
+		if (onlineStyleUrl) {
+			if (onlineStyleUrl.host === 'api.mapbox.com') {
+				if (
+					!onlineStyleUrl.searchParams.has('access_token') &&
+					VITE_MAPBOX_ACCESS_TOKEN
+				) {
+					onlineStyleUrl.searchParams.set(
+						'access_token',
+						VITE_MAPBOX_ACCESS_TOKEN,
+					)
+				} else {
+					console.warn(
+						'⚠️ Using a Mapbox map requires an access token. Either update the `ONLINE_STYLE_URL` env variable or specify the `VITE_MAPBOX_ACCESS_TOKEN` env variable',
+					)
+				}
 			}
 		}
 
@@ -138,7 +143,7 @@ class CoMapeoDesktopForgePlugin extends PluginBase {
 		const appConfig = {
 			appType: APP_TYPE,
 			asar: ASAR,
-			onlineStyleUrl: onlineStyleUrl.toString(),
+			onlineStyleUrl: onlineStyleUrl?.toString(),
 			userDataPath: USER_DATA_PATH,
 			appVersion: getAppVersion(packageJSON.version, APP_TYPE),
 		}

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -99,15 +99,18 @@ export async function start({ appConfig, configStore }) {
 
 	const rootKey = loadRootKey({ configStore })
 
-	const coreService = utilityProcess.fork(
-		CORE_SERVICE_PATH,
-		[
-			`--onlineStyleUrl=${appConfig.onlineStyleUrl}`,
-			`--rootKey=${rootKey}`,
-			`--storageDirectory=${app.getPath('userData')}`,
-		],
-		{ serviceName: `CoMapeo Core Service` },
-	)
+	const coreProcessArgs = [
+		`--rootKey=${rootKey}`,
+		`--storageDirectory=${app.getPath('userData')}`,
+	]
+
+	if (appConfig.onlineStyleUrl) {
+		coreProcessArgs.push(`--onlineStyleUrl=${appConfig.onlineStyleUrl}`)
+	}
+
+	const coreService = utilityProcess.fork(CORE_SERVICE_PATH, coreProcessArgs, {
+		serviceName: `CoMapeo Core Service`,
+	})
 
 	coreService.on('message', (message) => {
 		if (v.is(ServiceErrorMessageSchema, message)) {

--- a/src/main/validation.js
+++ b/src/main/validation.js
@@ -2,7 +2,7 @@ import * as v from 'valibot'
 
 export const AppConfigSchema = v.object({
 	asar: v.optional(v.boolean()),
-	onlineStyleUrl: v.pipe(v.string(), v.url()),
+	onlineStyleUrl: v.optional(v.pipe(v.string(), v.url())),
 	userDataPath: v.optional(v.string()),
 	appType: v.union([
 		v.literal('development'),

--- a/src/services/core.js
+++ b/src/services/core.js
@@ -52,7 +52,7 @@ const CORE_STORAGE_DIR_NAME = 'core-storage'
 const CUSTOM_MAPS_DIR_NAME = 'maps'
 
 const ProcessArgsSchema = v.object({
-	onlineStyleUrl: v.pipe(v.string(), v.url()),
+	onlineStyleUrl: v.optional(v.pipe(v.string(), v.url())),
 	rootKey: v.pipe(
 		v.string(),
 		v.hexadecimal(),
@@ -147,7 +147,7 @@ process.parentPort.on('message', (event) => {
 
 /**
  * @param {Object} opts
- * @param {string} opts.onlineStyleUrl
+ * @param {string} [opts.onlineStyleUrl]
  * @param {Buffer} opts.rootKey
  * @param {string} opts.storageDirectory
  */

--- a/src/shared/app.ts
+++ b/src/shared/app.ts
@@ -10,7 +10,7 @@ export type AppConfig = {
 	/** Enables ASAR format */
 	asar?: boolean
 	/** Sets the online map style for @comapeo/core to use */
-	onlineStyleUrl: string
+	onlineStyleUrl?: string
 	/** Sets the user data directory for the application to use */
 	userDataPath?: string
 	/** Indicates the app type */


### PR DESCRIPTION
Based on feedback from @rudokemper when setting up the development environment. Using a specific online style isn't necessary as core has its own defaults to use when setting it up if not configured.

---

Preview:

What the app looks like without configuring the variable:

<img width="600" height="1098" alt="image" src="https://github.com/user-attachments/assets/b1c09c2e-0b71-41e3-a0ed-48512fe26373" />
