### PR TITLE
fix: fix build error when building renderer

### DIFF
--- a/src/renderer/src/hooks/peers.ts
+++ b/src/renderer/src/hooks/peers.ts
@@ -1,7 +1,7 @@
 import { useRef, useSyncExternalStore } from 'react'
 import { useClientApi } from '@comapeo/core-react'
 import type { PublicPeerInfo } from '@comapeo/core/dist/mapeo-manager'
-import { type MapeoClientApi } from '@comapeo/ipc'
+import { type MapeoClientApi } from '@comapeo/ipc/client.js'
 import { isEqual } from 'radashi'
 
 export type LocalPeer = PublicPeerInfo


### PR DESCRIPTION
Pretty sure the issue lies in `@comapeo/ipc` or `rpc-reflector` where entry point being used for importing is pulling in a dep that relies on a node-only module, which vite cannot resolve without additional configuration. Changing the import to use the client-specific entry solves the problem, which is what we do throughout the renderer code, but forgot to do in this recently worked-on file. Probably should introduce some CI check to run the build to make sure that this doesn't happen again...

This is the original error that occurs when running `npm run vite:build`:

```console
error during build:
node_modules/ensure-error/index.js (1:8): "inspect" is not exported by "__vite-browser-external", imported by "node_modules/ensure-error/index.js".
file: /Users/andrewchou/GitHub/digidem/comapeo-desktop/node_modules/ensure-error/index.js:1:8

1: import {inspect} from 'node:util';
           ^
2: 
3: class NonError extends Error {

    at getRollupError (file:///Users/andrewchou/GitHub/digidem/comapeo-desktop/node_modules/rollup/dist/es/shared/parseAst.js:401:41)
    at error (file:///Users/andrewchou/GitHub/digidem/comapeo-desktop/node_modules/rollup/dist/es/shared/parseAst.js:397:42)
    at Module.error (file:///Users/andrewchou/GitHub/digidem/comapeo-desktop/node_modules/rollup/dist/es/shared/node-entry.js:16875:16)
    at Module.traceVariable (file:///Users/andrewchou/GitHub/digidem/comapeo-desktop/node_modules/rollup/dist/es/shared/node-entry.js:17327:29)
    at ModuleScope.findVariable (file:///Users/andrewchou/GitHub/digidem/comapeo-desktop/node_modules/rollup/dist/es/shared/node-entry.js:14997:39)
    at ChildScope.findVariable (file:///Users/andrewchou/GitHub/digidem/comapeo-desktop/node_modules/rollup/dist/es/shared/node-entry.js:5620:38)
    at ClassBodyScope.findVariable (file:///Users/andrewchou/GitHub/digidem/comapeo-desktop/node_modules/rollup/dist/es/shared/node-entry.js:5620:38)
    at ChildScope.findVariable (file:///Users/andrewchou/GitHub/digidem/comapeo-desktop/node_modules/rollup/dist/es/shared/node-entry.js:5620:38)
    at ChildScope.findVariable (file:///Users/andrewchou/GitHub/digidem/comapeo-desktop/node_modules/rollup/dist/es/shared/node-entry.js:5620:38)
    at FunctionScope.findVariable (file:///Users/andrewchou/GitHub/digidem/comapeo-desktop/node_modules/rollup/dist/es/shared/node-entry.js:5620:38)
```