### PR TITLE
fix: make Mongolian a selectable language

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -539,6 +539,10 @@
 		"nativeName": "മലയാളം",
 		"englishName": "Malayalam"
 	},
+	"mn": {
+		"nativeName": "Монгол",
+		"englishName": "Mongolian"
+	},
 	"mn-MN": {
 		"nativeName": "Монгол",
 		"englishName": "Mongolian"


### PR DESCRIPTION
The supported languages file didn't include the shortened language code for Mongolian and so it wasn't being detected as a language with translations available in the app.

---

Preview:

- Before:

    <img width="407" height="159" alt="image" src="https://github.com/user-attachments/assets/7a422045-5ab8-486c-b8e2-585cd188de45" />

- After:

    <img width="255" height="231" alt="image" src="https://github.com/user-attachments/assets/1b4ba84a-577a-485a-b033-5ef4d89015eb" />
