### PR TITLE
chore: update and pin GitHub actions

### DIFF
--- a/.github/parse-version/action.yml
+++ b/.github/parse-version/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash
     - name: Parse version name
       id: version
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
           const {version} = require('./package.json');

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -58,7 +58,7 @@ jobs:
       PR_HEAD_SHA: ${{ inputs.pr_head_sha || github.event.pull_request.head.sha }}
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@8ab05a8a84060745bdc8f0b4f6d8f403c29e06b8 # v2.1.1
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}

--- a/.github/workflows/check-pr-to-release.yml
+++ b/.github/workflows/check-pr-to-release.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout necessary files
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           sparse-checkout: |
             package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6 # v4.4.0
         with:
           node-version-file: '.nvmrc'
       - name: Install deps
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Use Node.js
         uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6 # v4.4.0
         with:
@@ -34,7 +34,7 @@ jobs:
         os: ['ubuntu-latest', 'macos-latest', 'macos-13', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Use Node.js
         uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6 # v4.4.0

--- a/.github/workflows/create-builds.yml
+++ b/.github/workflows/create-builds.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout repository
         env:
           BUILD_SHA: ${{ env.BUILD_SHA }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           ref: ${{ env.BUILD_SHA }}
           fetch-depth: 0

--- a/.github/workflows/create-builds.yml
+++ b/.github/workflows/create-builds.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os.image }}
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@8ab05a8a84060745bdc8f0b4f6d8f403c29e06b8 # v2.1.1
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
@@ -73,7 +73,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -96,7 +96,7 @@ jobs:
         run: node --run forge:make
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.os.name }}-${{ env.BUILD_SHA }}
           compression-level: 0

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@8ab05a8a84060745bdc8f0b4f6d8f403c29e06b8 # v2.1.1
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
@@ -69,7 +69,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6 # v4.4.0
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -63,7 +63,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           ref: ${{ env.RELEASE_BRANCH }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Check package-lock.json version has not been changed
-        uses: mansona/npm-lockfile-version@v1
+        uses: mansona/npm-lockfile-version@85d9138b7776b4f8f768259f8a3e4f2611457d8f # v1
         with:
           version: 3
   lockfile_changes:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@8ab05a8a84060745bdc8f0b4f6d8f403c29e06b8 # v2.1.1
         id: app-token

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check out a copy of the repo
         uses: actions/checkout@v4
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@8ab05a8a84060745bdc8f0b4f6d8f403c29e06b8 # v2.1.1
         id: app-token
         with:
           app-id: ${{ vars.LOCKFILE_BOT_APP_ID }}

--- a/.github/workflows/post-release-check.yml
+++ b/.github/workflows/post-release-check.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0

--- a/.github/workflows/post-release-check.yml
+++ b/.github/workflows/post-release-check.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@8ab05a8a84060745bdc8f0b4f6d8f403c29e06b8 # v2.1.1
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           sparse-checkout: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@8ab05a8a84060745bdc8f0b4f6d8f403c29e06b8 # v2.1.1
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@8ab05a8a84060745bdc8f0b4f6d8f403c29e06b8 # v2.1.1
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -42,7 +42,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           ref: ${{ env.TRUNK_BRANCH }}
           fetch-depth: 0

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@8ab05a8a84060745bdc8f0b4f6d8f403c29e06b8 # v2.1.1
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
@@ -49,7 +49,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6 # v4.4.0
         with:
           node-version-file: .nvmrc
 


### PR DESCRIPTION
Pinning is a precautionary measure against the security loophole of using version tags for actions (tags are mutable and thus can be pointed at bad commits if there's a compromise). More details here: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

Used a combination of https://github.com/suzuki-shunsuke/pinact and https://github.com/azat-io/actions-up to do this. In most cases, can probably rely on the latter for doing upgrades.