### PR TITLE
chore: extract getIconURL helper to lib

### DIFF
--- a/src/renderer/src/components/icon.tsx
+++ b/src/renderer/src/components/icon.tsx
@@ -1,6 +1,6 @@
 import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon'
 
-import ICONS_SPRITE_URL from '../images/icons-sprite.svg'
+import { getIconURL } from '../lib/icons'
 import type { IconName } from '../types/icons.generated'
 
 export function Icon({
@@ -32,8 +32,4 @@ export function Icon({
 			<use href={getIconURL(name)} />
 		</SvgIcon>
 	)
-}
-
-export function getIconURL(iconName: IconName) {
-	return `${ICONS_SPRITE_URL}#${iconName}`
 }

--- a/src/renderer/src/components/zoom-to-data-map-control.tsx
+++ b/src/renderer/src/components/zoom-to-data-map-control.tsx
@@ -9,7 +9,7 @@ import {
 } from 'maplibre-gl'
 import { useControl, type MapInstance } from 'react-map-gl/maplibre'
 
-import { getIconURL } from './icon'
+import { getIconURL } from '../lib/icons'
 
 type ControlOptions = {
 	buttonTitle: string

--- a/src/renderer/src/lib/icons.ts
+++ b/src/renderer/src/lib/icons.ts
@@ -1,0 +1,6 @@
+import ICONS_SPRITE_URL from '../images/icons-sprite.svg'
+import type { IconName } from '../types/icons.generated'
+
+export function getIconURL(iconName: IconName) {
+	return `${ICONS_SPRITE_URL}#${iconName}`
+}


### PR DESCRIPTION
Exporting it with a component from a file apparently doesn't play nicely with fast refresh: https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#consistent-components-exports. Probably helpful to do this for isolation anyways.