### PR TITLE
fix: use correct icon for app settings page

### DIFF
--- a/src/renderer/src/routes/app/settings/index.tsx
+++ b/src/renderer/src/routes/app/settings/index.tsx
@@ -74,11 +74,7 @@ function RouteComponent() {
 				alignItems="center"
 				padding={6}
 			>
-				<Icon
-					name="material-symbols-info"
-					size={100}
-					htmlColor={DARKER_ORANGE}
-				/>
+				<Icon name="material-settings" size={100} htmlColor={DARKER_ORANGE} />
 
 				<Typography variant="h1" fontWeight={500}>
 					{t(m.title)}


### PR DESCRIPTION
Not sure how I didn't notice this one...

---

Preview:

- Before

    <img width="600" height="1094" alt="image" src="https://github.com/user-attachments/assets/12ccd0f6-30b6-4f03-b856-8b6ecaf54266" />


- After:

    <img width="600" height="1097" alt="image" src="https://github.com/user-attachments/assets/c06ba0eb-d975-45bf-ae40-ccc97bb2a602" />
