### PR TITLE
feat: show remote archive indicator in exchange page

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -241,6 +241,10 @@
     "description": "Text displayed when no devices have been found.",
     "message": "No Devices Found"
   },
+  "routes.app.projects.$projectId_.exchange.index.remoteArchiveConnected": {
+    "description": "Text indicating that some remote archive is connected.",
+    "message": "Remote Archive connected"
+  },
   "routes.app.projects.$projectId_.exchange.index.start": {
     "description": "Button text to start exchange.",
     "message": "Start"

--- a/src/renderer/icons/material-circle-filled.svg
+++ b/src/renderer/icons/material-circle-filled.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0z"/><path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2z"/></svg>

--- a/src/renderer/src/images/icons-sprite.svg
+++ b/src/renderer/src/images/icons-sprite.svg
@@ -420,6 +420,12 @@
 				d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
 			></path>
 		</symbol>
+		<symbol viewBox="0 0 24 24" id="material-circle-filled">
+			<path fill="none" d="M0 0h24v24H0z"></path>
+			<path
+				d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2z"
+			></path>
+		</symbol>
 		<symbol viewBox="0 0 24 24" id="material-chevron-right">
 			<path fill="none" d="M0 0h24v24H0V0z"></path>
 			<path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6-6-6z"></path>

--- a/src/renderer/src/types/icons.generated.ts
+++ b/src/renderer/src/types/icons.generated.ts
@@ -40,6 +40,7 @@ export const iconNames = [
 	'material-expand-more',
 	'material-expand-less',
 	'material-error',
+	'material-circle-filled',
 	'material-chevron-right',
 	'material-check',
 	'material-check-circle',


### PR DESCRIPTION
Closes #176 

Shows under the following conditions:

1. the project has at least 1 active remote archive set up. no additional checks are made to know if it's actually online and ready to exchange.

2. Some wifi network is connected, regardless of internet access. Without some tedious pinging or additional changes to core, we can't directly check if a remote archive is online and ready to exchange.

---

Preview:

<img width="600" height="1097" alt="image" src="https://github.com/user-attachments/assets/31963117-09ab-44c5-bcfe-ab810405a2aa" />
