### PR TITLE
chore: do not include languages that have no translated messages

### DIFF
--- a/scripts/generate-translated-languages-list.js
+++ b/scripts/generate-translated-languages-list.js
@@ -3,7 +3,7 @@
 import fs from 'node:fs'
 import { glob } from 'node:fs/promises'
 import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import * as v from 'valibot'
 
 import SUPPORTED_LANGUAGES from '../languages.json' with { type: 'json' }
@@ -56,9 +56,10 @@ for await (const entry of glob('*.json', { cwd: RENDERER_MESSAGES_DIR })) {
 		continue
 	}
 
-	const messages = await import(join(RENDERER_MESSAGES_DIR, entry), {
-		with: { type: 'json' },
-	})
+	const messages = await import(
+		pathToFileURL(join(RENDERER_MESSAGES_DIR, entry)).href,
+		{ with: { type: 'json' } }
+	)
 
 	// If a language is added to Crowdin but has no translated messages,
 	// Crowdin still creates an empty file. We do not include as a selectable language.


### PR DESCRIPTION
Surfaced as a result of looking at #268 , in which some languages have been added on CrowdIn but no translations have been provided.

This aligns more closely to what [mobile](https://github.com/digidem/comapeo-mobile/blob/a530f0d97dea0cf542b5466224e1cc09f91c9db8/scripts/build-translations.mjs#L56-L58) does when processing messages.