### PR TITLE
fix: fix script for generating translated languages

### DIFF
--- a/scripts/generate-translated-languages-list.js
+++ b/scripts/generate-translated-languages-list.js
@@ -1,9 +1,9 @@
 // Creates a JSON file that lists the language tags for which we have renderer translations.
 // This is done so that this info is known at compile time instead of being calculated during run time.
-import fs from 'node:fs'
+import fs, { readFileSync } from 'node:fs'
 import { glob } from 'node:fs/promises'
 import { join } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
 import * as v from 'valibot'
 
 import SUPPORTED_LANGUAGES from '../languages.json' with { type: 'json' }
@@ -56,9 +56,10 @@ for await (const entry of glob('*.json', { cwd: RENDERER_MESSAGES_DIR })) {
 		continue
 	}
 
-	const messages = await import(
-		pathToFileURL(join(RENDERER_MESSAGES_DIR, entry)).href,
-		{ with: { type: 'json' } }
+	const messages = JSON.parse(
+		readFileSync(join(RENDERER_MESSAGES_DIR, entry), {
+			encoding: 'utf-8',
+		}),
 	)
 
 	// If a language is added to Crowdin but has no translated messages,


### PR DESCRIPTION
Follow-up to #269 . Tried to be fancy with it using import assertions which led to me forgetting that the result is a module object and not the JSON content itself. Going to back to good ol' readFileSync + json parse