### PR TITLE
fix: redirect user to an existing project when active project ID is missing

### DIFF
--- a/src/renderer/src/routes/app/route.tsx
+++ b/src/renderer/src/routes/app/route.tsx
@@ -26,7 +26,7 @@ import { GLOBAL_MUTATIONS_BASE_KEY } from '../../lib/queries/global-mutations'
 export const Route = createFileRoute('/app')({
 	beforeLoad: ({ context, matches }) => {
 		if (!context.activeProjectId) {
-			throw new Error('Router context is missing `activeProjectId')
+			throw new Error('Router context is missing `activeProjectId`')
 		}
 
 		// Redirect to project-specific "initial" page if the current route is the just /app

--- a/src/renderer/src/routes/index.tsx
+++ b/src/renderer/src/routes/index.tsx
@@ -14,6 +14,7 @@ export const Route = createFileRoute('/')({
 			},
 		})
 
+		// NOTE: Implicit check that the user hasn't completed the onboarding yet.
 		if (!ownDeviceInfo.name) {
 			throw redirect({ to: '/welcome', replace: true })
 		}

--- a/src/renderer/src/routes/index.tsx
+++ b/src/renderer/src/routes/index.tsx
@@ -1,13 +1,12 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
 import { COMAPEO_CORE_REACT_ROOT_QUERY_KEY } from '../lib/comapeo'
+import { getActiveProjectIdQueryOptions } from '../lib/queries/app-settings'
 
 export const Route = createFileRoute('/')({
 	beforeLoad: async ({ context }) => {
 		const { queryClient, clientApi, activeProjectId } = context
 
-		// TODO: not ideal to do this but requires major changes to @comapeo/core-react
-		// copied from https://github.com/digidem/comapeo-core-react/blob/e56979321e91440ad6e291521a9e3ce8eb91200d/src/lib/react-query/client.ts#L21
 		const ownDeviceInfo = await queryClient.ensureQueryData({
 			queryKey: [COMAPEO_CORE_REACT_ROOT_QUERY_KEY, 'client', 'device_info'],
 			queryFn: async () => {
@@ -19,16 +18,45 @@ export const Route = createFileRoute('/')({
 			throw redirect({ to: '/welcome', replace: true })
 		}
 
-		if (!activeProjectId) {
+		if (activeProjectId) {
 			throw redirect({
-				to: '/onboarding/project',
+				to: '/app/projects/$projectId',
+				params: { projectId: activeProjectId },
 				replace: true,
 			})
 		}
 
+		// NOTE: Accounts for when the active project ID is somehow missing
+		// but there are already projects that have been created/joined.
+		// The better solution is probably a project selection page of some sort,
+		// as opposed to automatic redirection to a valid project.
+
+		const projects = await queryClient.ensureQueryData({
+			queryKey: [COMAPEO_CORE_REACT_ROOT_QUERY_KEY, 'projects'],
+			queryFn: async () => {
+				return clientApi.listProjects()
+			},
+		})
+
+		const projectToUse = projects[0]
+
+		if (projectToUse) {
+			await window.runtime.setActiveProjectId(projectToUse.projectId)
+
+			await queryClient.invalidateQueries({
+				queryKey: getActiveProjectIdQueryOptions().queryKey,
+			})
+
+			throw redirect({
+				to: '/app/projects/$projectId',
+				params: { projectId: projectToUse.projectId },
+				replace: true,
+				reloadDocument: true,
+			})
+		}
+
 		throw redirect({
-			to: '/app/projects/$projectId',
-			params: { projectId: activeProjectId },
+			to: '/onboarding/project',
 			replace: true,
 		})
 	},


### PR DESCRIPTION
If the `activeProjectId` is missing on app start, we typically redirect the user to the onboarding flow, which is >99% of the cases that will happen. There's a <1% chance that the user has already created/joined a project but somehow the `activeProjectId` is missing, in which case it's preferable to prevent the user from going through the onboarding flow. This PR addresses this by redirecting the user to _some_ valid project. It's an edge case and the solution here feels like a short-term one. In the long-term, I think it'd be better to redirect the user to some project selection page where they can decide which project to enter (or even create/join a new one)