### PR TITLE
chore: make fastify an explicit dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"atomically": "2.0.3",
 				"debug": "4.4.1",
 				"electron-squirrel-startup": "1.0.1",
+				"fastify": "4.29.1",
 				"sodium-native": "4.3.3",
 				"systeminformation": "5.27.8",
 				"valibot": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"atomically": "2.0.3",
 		"debug": "4.4.1",
 		"electron-squirrel-startup": "1.0.1",
+		"fastify": "4.29.1",
 		"sodium-native": "4.3.3",
 		"systeminformation": "5.27.8",
 		"valibot": "1.1.0",


### PR DESCRIPTION
We directly import from Fastify in the core service in order to set up the manager. Pretty sure this hints that Fastify should be declared as a peer dep in core, but not a big deal.