### PR TITLE
chore: add improvements to intl setup in main process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"fastify": "4.29.1",
 				"sodium-native": "4.3.3",
 				"systeminformation": "5.27.8",
+				"tiny-typed-emitter": "2.1.0",
 				"valibot": "1.1.0",
 				"zustand": "5.0.8"
 			},

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"fastify": "4.29.1",
 		"sodium-native": "4.3.3",
 		"systeminformation": "5.27.8",
+		"tiny-typed-emitter": "2.1.0",
 		"valibot": "1.1.0",
 		"zustand": "5.0.8"
 	},

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -21,7 +21,7 @@ import {
 	FilesSelectParamsSchema,
 	ImportSMPFileParamsSchema,
 } from '../shared/ipc.ts'
-import { Intl } from './intl.ts'
+import { IntlManager } from './intl-manager.ts'
 import { setUpMainIPC } from './ipc.ts'
 import type { PersistedStore } from './persisted-store.ts'
 import { ServiceErrorMessageSchema } from './service-error.ts'
@@ -77,19 +77,19 @@ export async function start({
 		APP_STATE.tryingToQuitApp = false
 	})
 
-	const intl = new Intl({
+	const intlManager = new IntlManager({
 		initialLocale: persistedStore.getState().locale,
 	})
 
 	persistedStore.subscribe((current, previous) => {
 		if (previous.locale !== current.locale) {
-			intl.updateLocale(current.locale)
+			intlManager.updateLocale(current.locale)
 		}
 	})
 
 	app.setAboutPanelOptions({ applicationVersion: appConfig.appVersion })
 
-	setUpMainIPC({ persistedStore, intl })
+	setUpMainIPC({ persistedStore, intlManager })
 
 	await app.whenReady()
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3,7 +3,7 @@ import { ipcMain } from 'electron/main'
 import si from 'systeminformation'
 import * as v from 'valibot'
 
-import { type Intl } from './intl.ts'
+import type { IntlManager } from './intl-manager.ts'
 import {
 	PersistedStateV1Schema,
 	type PersistedStore,
@@ -11,10 +11,10 @@ import {
 
 export function setUpMainIPC({
 	persistedStore,
-	intl,
+	intlManager,
 }: {
 	persistedStore: PersistedStore
-	intl: Intl
+	intlManager: IntlManager
 }) {
 	// Shell
 	ipcMain.handle('shell:open-external-url', (_event, url) => {
@@ -41,7 +41,7 @@ export function setUpMainIPC({
 	})
 
 	ipcMain.handle('settings:get:locale', () => {
-		return intl.localeState
+		return intlManager.localeState
 	})
 
 	// Settings (set)


### PR DESCRIPTION
Adding localization support for things managed in the main process is still in its early stages and not used meaningfully just yet. Was revisiting it as I'm thinking about translations for native controls like the app menu and context menu, and noticed a couple of issues and shortcomings.

This PR updates our setup in the following ways:

- renames our custom `Intl` class to `IntlManager`. `Intl` is a global namespace object so we rename our implementation to avoid confusion.

- Make the `IntlManager` an event emitter. This will be useful for regenerating the user-facing translated labels of native UI. We emit a `locale-state` event that provides the locale state as the event payload when it changes.

- fixes the loading of translations. before we were using JSON module import syntax and only loading the messages for a hardcoded list of english, spanish, and portuguese. now we attempt to load and cache the messages based on the language of interest, with english being the only one that we load ahead of time.