### PR TITLE
fix: fix fallback go-back behavior for observation attachment page

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/attachments/$driveId.$type.$variant.$name.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/attachments/$driveId.$type.$variant.$name.tsx
@@ -64,7 +64,7 @@ function RouteComponent() {
 
 	const router = useRouter()
 
-	const { projectId, ...blobId } = Route.useParams()
+	const { projectId, observationDocId, ...blobId } = Route.useParams()
 
 	const errorResetKey = `${blobId.driveId}/${blobId.type}/${blobId.variant}/${blobId.name}`
 
@@ -86,8 +86,8 @@ function RouteComponent() {
 						}
 
 						router.navigate({
-							to: '/app/projects/$projectId',
-							params: { projectId },
+							to: '/app/projects/$projectId/observations/$observationDocId',
+							params: { projectId, observationDocId },
 							replace: true,
 						})
 					}}


### PR DESCRIPTION
Forgot to update the fallback behavior of the back button after copy-pasting from a different page.