### PR TITLE
fix: adjust window customization for linux and windows

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -292,6 +292,8 @@ function initMainWindow({
 		},
 	})
 
+	mainWindow.setAutoHideMenuBar(true)
+
 	if (isDevelopment) {
 		// TODO: Don't hard code ideally
 		mainWindow.loadURL('http://localhost:5173/')

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -281,6 +281,7 @@ function initMainWindow({
 		backgroundColor: '#050F77',
 		titleBarStyle: 'hiddenInset',
 		titleBarOverlay: true,
+		accentColor: '#2348B2',
 		webPreferences: {
 			preload: MAIN_WINDOW_PRELOAD_PATH,
 			additionalArguments: [

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -118,7 +118,8 @@ initSentryElectron(
 
 const { platform } = window.runtime.getAppInfo()
 
-const MAIN_CONTENT_HEIGHT = `calc(100% - ${TITLE_BAR_HEIGHT})`
+const MAIN_CONTENT_HEIGHT =
+	platform === 'darwin' ? `calc(100% - ${TITLE_BAR_HEIGHT})` : '100%'
 
 const refreshTokensStore = createRefreshTokensStore()
 
@@ -134,7 +135,9 @@ export function App() {
 							<NetworkConnectionChangeListener />
 
 							<Box height="100dvh">
-								<AppTitleBar platform={platform} />
+								{platform === 'darwin' ? (
+									<AppTitleBar platform={platform} />
+								) : null}
 
 								<Box height={MAIN_CONTENT_HEIGHT}>
 									<Suspense


### PR DESCRIPTION
Closes #281 

There's probably much more interesting customizations that can be done but for now, went with what felt simple to implement.

- Hide our custom title bar on windows and linux, deferring to the native ones.
- Allow toggling the visibility of the menu bar (by using the `Alt` key)
- Set the accent color for windows, which is used for the native title bar

---

Preview:

- Windows:


- Linux (GNOME):