### PR TITLE
fix: fix navigation issues related to post-onboarding invite flow

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -365,6 +365,18 @@
     "description": "Text displayed when external device is disconnected.",
     "message": "Disconnected"
   },
+  "routes.app.projects.$projectId_.invite.devices.index.discoveryTroubleshootingSameNetwork": {
+    "description": "Text explaining that devices need to be on same Wi-Fi network.",
+    "message": "Check that devices are on the same Wi-Fi network"
+  },
+  "routes.app.projects.$projectId_.invite.devices.index.discoveryTroubleshootingSameVersion": {
+    "description": "Text explaining that devices need to be using same version of CoMapeo.",
+    "message": "Confirm that devices are using the same version of CoMapeo"
+  },
+  "routes.app.projects.$projectId_.invite.devices.index.discoveryTroubleshootingTitle": {
+    "description": "Title for device discovery troubleshooting section.",
+    "message": "Not seeing a device?"
+  },
   "routes.app.projects.$projectId_.invite.devices.index.gettingWifiInfo": {
     "description": "Text displayed when waiting for Wi-Fi information.",
     "message": "Getting Wi-Fi information…"

--- a/src/renderer/src/lib/navigation.ts
+++ b/src/renderer/src/lib/navigation.ts
@@ -8,8 +8,6 @@ export type ToRoute = FileRouteTypes['to']
 export type ToRouteParams<T extends ToRoute> =
 	keyof FileRoutesByTo[T]['options']['params']
 
-export type ToRouteFullPath = FileRouteTypes['fullPaths']
-
 export type ToRouteId = FileRouteTypes['id']
 
 export const CustomNotFoundDataSchema = v.object({

--- a/src/renderer/src/routes/app/projects/$projectId_/invite/devices/$deviceId/role.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/invite/devices/$deviceId/role.tsx
@@ -47,11 +47,6 @@ function RouteComponent() {
 			>
 				<IconButton
 					onClick={() => {
-						if (router.history.canGoBack()) {
-							router.history.back()
-							return
-						}
-
 						router.navigate({
 							to: '/app/projects/$projectId/invite/devices',
 							params: { projectId },
@@ -94,6 +89,7 @@ function RouteComponent() {
 								to: '/app/projects/$projectId/invite/devices/$deviceId/send',
 								params: { projectId, deviceId: peer.deviceId },
 								search: { role: 'participant' },
+								replace: true,
 							})
 						}}
 					/>
@@ -107,6 +103,7 @@ function RouteComponent() {
 								to: '/app/projects/$projectId/invite/devices/$deviceId/send',
 								params: { projectId, deviceId: peer.deviceId },
 								search: { role: 'coordinator' },
+								replace: true,
 							})
 						}}
 					/>

--- a/src/renderer/src/routes/app/projects/$projectId_/invite/devices/$deviceId/send.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/invite/devices/$deviceId/send.tsx
@@ -177,7 +177,6 @@ function RouteComponent() {
 					to="/app/projects/$projectId/invite/devices"
 					params={{ projectId }}
 					replace
-					reloadDocument
 				/>
 			)
 		}
@@ -220,14 +219,9 @@ function ReviewInvitation({
 				>
 					<IconButton
 						onClick={() => {
-							if (router.history.canGoBack()) {
-								router.history.back()
-								return
-							}
-
 							router.navigate({
-								to: '/app/projects/$projectId/invite/devices',
-								params: { projectId },
+								to: '/app/projects/$projectId/invite/devices/$deviceId/role',
+								params: { projectId, deviceId },
 								replace: true,
 							})
 						}}
@@ -446,7 +440,6 @@ function InviteRejected({
 						to="/app/projects/$projectId/invite"
 						params={{ projectId }}
 						replace
-						reloadDocument
 						fullWidth
 						variant="contained"
 						sx={{ maxWidth: 400, alignSelf: 'center' }}
@@ -558,7 +551,6 @@ function InviteAccepted({
 						to="/app/projects/$projectId/invite/devices"
 						params={{ projectId }}
 						replace
-						reloadDocument
 						fullWidth
 						variant="outlined"
 						sx={{ maxWidth: 400, alignSelf: 'center' }}
@@ -570,7 +562,6 @@ function InviteAccepted({
 						to="/app/projects/$projectId/settings/team"
 						params={{ projectId }}
 						replace
-						reloadDocument
 						fullWidth
 						variant="contained"
 						sx={{ maxWidth: 400, alignSelf: 'center' }}

--- a/src/renderer/src/routes/app/projects/$projectId_/invite/devices/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/invite/devices/index.tsx
@@ -94,18 +94,18 @@ function RouteComponent() {
 					<Divider sx={{ bgcolor: LIGHT_GREY }} />
 
 					<Stack direction="column" padding={6}>
-						<Typography>Not seeing a device?</Typography>
+						<Typography>{t(m.discoveryTroubleshootingTitle)}</Typography>
 
 						<List sx={{ listStyleType: 'disc', paddingInline: 8 }}>
 							<ListItem disablePadding sx={{ display: 'list-item' }}>
 								<Typography color="textPrimary" variant="body2">
-									Check that devices are on the same Wi-Fi network
+									{t(m.discoveryTroubleshootingSameNetwork)}
 								</Typography>
 							</ListItem>
 
 							<ListItem disablePadding sx={{ display: 'list-item' }}>
 								<Typography variant="body2" color="textPrimary">
-									Confirm that devices are using the same version of CoMapeo
+									{t(m.discoveryTroubleshootingSameVersion)}
 								</Typography>
 							</ListItem>
 						</List>
@@ -163,6 +163,7 @@ function InvitablePeersList({ projectId }: { projectId: string }) {
 										navigate({
 											to: '/app/projects/$projectId/invite/devices/$deviceId/role',
 											params: { projectId, deviceId: peer.deviceId },
+											replace: true,
 										})
 									}
 								: undefined
@@ -192,5 +193,23 @@ const m = defineMessages({
 		id: 'routes.app.projects.$projectId_.invite.devices.index.gettingWifiInfo',
 		defaultMessage: 'Getting Wi-Fi information…',
 		description: 'Text displayed when waiting for Wi-Fi information.',
+	},
+	discoveryTroubleshootingTitle: {
+		id: 'routes.app.projects.$projectId_.invite.devices.index.discoveryTroubleshootingTitle',
+		defaultMessage: 'Not seeing a device?',
+		description: 'Title for device discovery troubleshooting section.',
+	},
+	discoveryTroubleshootingSameNetwork: {
+		id: 'routes.app.projects.$projectId_.invite.devices.index.discoveryTroubleshootingSameNetwork',
+		defaultMessage: 'Check that devices are on the same Wi-Fi network',
+		description:
+			'Text explaining that devices need to be on same Wi-Fi network.',
+	},
+	discoveryTroubleshootingSameVersion: {
+		id: 'routes.app.projects.$projectId_.invite.devices.index.discoveryTroubleshootingSameVersion',
+		defaultMessage:
+			'Confirm that devices are using the same version of CoMapeo',
+		description:
+			'Text explaining that devices need to be using same version of CoMapeo.',
 	},
 })

--- a/src/renderer/src/routes/app/projects/$projectId_/invite/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/invite/index.tsx
@@ -145,6 +145,7 @@ function RouteComponent() {
 					<ButtonLink
 						to="/app/projects/$projectId/invite/devices"
 						params={{ projectId }}
+						replace
 						type="button"
 						fullWidth
 						sx={{ maxWidth: 400 }}

--- a/src/renderer/src/routes/app/route.tsx
+++ b/src/renderer/src/routes/app/route.tsx
@@ -20,7 +20,6 @@ import {
 	IconButtonLink,
 	type ButtonLinkProps,
 } from '../../components/link'
-import type { ToRouteFullPath } from '../../lib/navigation'
 import { GLOBAL_MUTATIONS_BASE_KEY } from '../../lib/queries/global-mutations'
 
 export const Route = createFileRoute('/app')({
@@ -61,7 +60,15 @@ function RouteComponent() {
 	const syncState = useSyncState({ projectId: activeProjectId })
 	const syncEnabled = syncState?.data.isSyncEnabled
 
-	const pageHasEditing = checkPageHasEditing(currentRoute.fullPath)
+	const pageHasEditing =
+		currentRoute.routeId === '/app/settings/device-name' ||
+		currentRoute.routeId === '/app/settings/coordinate-system' ||
+		currentRoute.routeId === '/app/settings/language' ||
+		currentRoute.routeId === '/app/projects/$projectId_/settings/info' ||
+		currentRoute.routeId ===
+			'/app/projects/$projectId_/invite/devices/$deviceId/role' ||
+		currentRoute.routeId ===
+			'/app/projects/$projectId_/invite/devices/$deviceId/send'
 
 	const someGlobalMutationIsPending =
 		useIsMutating({ mutationKey: GLOBAL_MUTATIONS_BASE_KEY }) > 0
@@ -250,17 +257,6 @@ const SHARED_NAV_ITEM_PROPS = {
 		},
 	},
 } as const
-
-function checkPageHasEditing(currentPath: ToRouteFullPath) {
-	return (
-		currentPath === '/app/settings/device-name' ||
-		currentPath === '/app/settings/coordinate-system' ||
-		currentPath === '/app/settings/language' ||
-		currentPath === '/app/projects/$projectId/settings/info' ||
-		currentPath === '/app/projects/$projectId/invite/devices/$deviceId/role' ||
-		currentPath === '/app/projects/$projectId/invite/devices/$deviceId/send'
-	)
-}
 
 const m = defineMessages({
 	aboutTabLabel: {


### PR DESCRIPTION
Fixes #248 

Basically needed to meticulously make sure that navigations within the flow are replacing the URL as opposed to pushing new entries. Kind of tedious and annoying but it's a much smaller diff than I was expecting.

Also fixes an issue with some strings not being set up for translation.