### PR TITLE
chore: update builds workflow to use metrics URL from action vars

### DIFF
--- a/.github/workflows/create-builds.yml
+++ b/.github/workflows/create-builds.yml
@@ -85,7 +85,7 @@ jobs:
         env:
           APP_TYPE: ${{ inputs.app_type }}
           COMAPEO_METRICS_ACCESS_TOKEN: ${{ secrets.COMAPEO_METRICS_ACCESS_TOKEN }}
-          COMAPEO_DIAGNOSTICS_METRICS_URL: ${{ secrets.COMAPEO_DIAGNOSTICS_METRICS_URL }}
+          COMAPEO_DIAGNOSTICS_METRICS_URL: ${{ vars.COMAPEO_DIAGNOSTICS_METRICS_URL }}
           ONLINE_STYLE_URL: ${{ secrets.ONLINE_STYLE_URL }}
           VITE_FEATURE_TEST_DATA_UI: ${{ env.APP_TYPE == 'production' && 'false' || 'true' }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
Aligns with what mobile has done recently. I added the variable for the repo that points to the newly updated URL that should be used, as opposed to the old one.