### PR TITLE
chore: fix url for build-rc comment

### DIFF
--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -68,8 +68,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
           COMMENT_BODY: |
-            :construction: Release candidate build based on ${{ env.BUILD_SHA }} (potential merge of ${{ env.PR_HEAD_SHA }}): ${{ needs.build.outputs.artifact-url }}
+            :construction: Release candidate build based on ${{ env.BUILD_SHA }} (potential merge of ${{ env.PR_HEAD_SHA }}). Assets can be found in the `Artifacts` section of ${{ env.RUN_URL }}
 
         run: |
           gh pr comment $PR_NUMBER --body "$COMMENT_BODY" --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/create-builds.yml
+++ b/.github/workflows/create-builds.yml
@@ -14,10 +14,6 @@ on:
         description: 'SHA of commit to build'
         required: true
         type: string
-    outputs:
-      artifact-url:
-        description: 'URL pointing to the uploaded artifact'
-        value: ${{ jobs.builds.outputs.artifact-url }}
 
   workflow_dispatch:
     inputs:
@@ -59,8 +55,6 @@ jobs:
             { name: 'windows', image: 'windows-latest' },
           ]
     runs-on: ${{ matrix.os.image }}
-    outputs:
-      artifact-url: ${{ steps.artifact.outputs.artifact-url }}
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
@@ -102,7 +96,6 @@ jobs:
         run: node --run forge:make
 
       - name: Upload artifact
-        id: artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: builds-${{ matrix.os.name }}-${{ env.BUILD_SHA }}


### PR DESCRIPTION
Basically undoes #316 as I forgot that the artifact URL output is per matrix option, which doesn't work for our needs. Also causes a warning from GitHub that probably would've caused things to not work anyways:

<img width="502" height="344" alt="image" src="https://github.com/user-attachments/assets/7d1960b2-1e2b-46e2-a342-66341f649006" />

Instead we opt for getting the action run URL and pointing to that. Updates the comment a bit to make it clearer where in that page to look.