### PR TITLE
fix: handle displaying invalid tracks on map

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -101,6 +101,10 @@
     "description": "Title for list item that is a track.",
     "message": "Track"
   },
+  "routes.app.projects.$projectId.-displayed.data.map.cannotDisplayFeature": {
+    "description": "Text displayed when map feature for selected data cannot be displayed",
+    "message": "Cannot display feature"
+  },
   "routes.app.projects.$projectId.-displayed.data.map.categoryIconAlt": {
     "description": "Alt text for icon image displayed for category (used for accessibility tools).",
     "message": "Icon for {name} category"


### PR DESCRIPTION
Fixes #289

Does not update the test data page to add validation for minimum locations needed when creating a track. Would rather that be handled at the schema level (see https://github.com/digidem/comapeo-schema/issues/308). Also makes some minor adjustments to the map panning behavior in some cases (e.g. focusing on selected track). 