### PR TITLE
fix: fix broken links after onboarding project creation

### DIFF
--- a/src/renderer/src/routes/index.tsx
+++ b/src/renderer/src/routes/index.tsx
@@ -52,6 +52,7 @@ export const Route = createFileRoute('/')({
 				to: '/app/projects/$projectId',
 				params: { projectId: projectToUse.projectId },
 				replace: true,
+				reloadDocument: true,
 			})
 		}
 


### PR DESCRIPTION
Noticed the links after creating an onboarding navigated to the project page, which is not the desired behavior. Think it has to do with some changed behavior in router related to how `reloadDocument` works (pretty sure it used to not have this issue in the past).