### PR TITLE
chore: update image used for macOS Intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'macos-13', 'windows-latest']
+        os:
+          ['ubuntu-latest', 'macos-latest', 'macos-15-intel', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -81,7 +82,7 @@ jobs:
           [
             { name: 'linux', image: 'ubuntu-latest' },
             { name: 'macos', image: 'macos-latest' },
-            { name: 'macos-intel', image: 'macos-13' },
+            { name: 'macos-intel', image: 'macos-15-intel' },
             { name: 'windows', image: 'windows-latest' },
           ]
     runs-on: ${{ matrix.os.image }}

--- a/.github/workflows/create-builds.yml
+++ b/.github/workflows/create-builds.yml
@@ -51,7 +51,7 @@ jobs:
           [
             { name: 'linux', image: 'ubuntu-latest' },
             { name: 'macos', image: 'macos-latest' },
-            { name: 'macos-intel', image: 'macos-13' },
+            { name: 'macos-intel', image: 'macos-15-intel' },
             { name: 'windows', image: 'windows-latest' },
           ]
     runs-on: ${{ matrix.os.image }}


### PR DESCRIPTION
A deprecation notice of the macOS 13 images was announced last month and is planned to be removed in early December (see https://github.com/actions/runner-images/issues/13046). This PR updates workflows using macOS Intel images to use the recently provided `macos-15-intel` image that will be supported until August 2027 (see https://github.com/actions/runner-images/issues/13045). Note that this is the last Intel-based macOS image that will be provided and after the stated support period, only arm-based macOS images will be available.

This means that macOS Intel builds will now be created using macOS 15 (which shouldn't have any noticeable end-user effects).