### PR TITLE
chore: enable Sentry in core service

### DIFF
--- a/src/services/core.ts
+++ b/src/services/core.ts
@@ -6,6 +6,7 @@ import { parseArgs } from 'node:util'
 import { FastifyController, MapeoManager } from '@comapeo/core'
 import { createMapeoServer } from '@comapeo/ipc/server.js'
 import ciao, { type Protocol } from '@homebridge/ciao'
+import * as Sentry from '@sentry/electron/utility'
 import debug from 'debug'
 import type { MessagePortMain } from 'electron'
 import Fastify from 'fastify'
@@ -13,6 +14,8 @@ import sodium from 'sodium-native'
 import * as v from 'valibot'
 
 import type { ServiceErrorMessage } from '../main/service-error.js'
+
+Sentry.init()
 
 const log = debug('comapeo:services:core')
 


### PR DESCRIPTION
Had no idea that I needed to explicitly set up Sentry in utility processes as I thought that was handled via the primary electron SDK 😅 In all fairness, it's not really documented and I had to figure this out by looking at https://github.com/getsentry/sentry-electron/pull/991.