### PR TITLE
fix: fix getting initial project ID when doing manual browser page reload

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -41,20 +41,6 @@ export function setUpMainIPC({
 	})
 
 	// Settings (set)
-	ipcMain.handle('activeProjectId:set', (_event, value) => {
-		v.assert(
-			v.union([
-				v.nonOptional(PersistedStateV1Schema.entries.activeProjectId),
-				v.null(),
-			]),
-			value,
-		)
-
-		persistedStore.setState({
-			activeProjectId: value === null ? undefined : value,
-		})
-	})
-
 	ipcMain.handle('settings:set:coordinateFormat', (_event, value) => {
 		v.assert(
 			v.nonOptional(PersistedStateV1Schema.entries.coordinateFormat),
@@ -74,5 +60,27 @@ export function setUpMainIPC({
 	ipcMain.handle('settings:set:locale', (_event, value) => {
 		v.assert(v.nonOptional(PersistedStateV1Schema.entries.locale), value)
 		persistedStore.setState({ locale: value })
+	})
+
+	// Active project ID
+
+	// NOTE: This is handled as a synchronous call, which is generally not recommended.
+	// This should only be used in initialization before mounting the rendered app.
+	ipcMain.on('activeProjectId:get', (event) => {
+		event.returnValue = persistedStore.getState().activeProjectId
+	})
+
+	ipcMain.handle('activeProjectId:set', (_event, value) => {
+		v.assert(
+			v.union([
+				v.nonOptional(PersistedStateV1Schema.entries.activeProjectId),
+				v.null(),
+			]),
+			value,
+		)
+
+		persistedStore.setState({
+			activeProjectId: value === null ? undefined : value,
+		})
 	})
 }

--- a/src/preload/main-window.js
+++ b/src/preload/main-window.js
@@ -86,11 +86,15 @@ const runtimeApi = {
 
 	// Active project ID
 	getInitialProjectId: () => {
-		const projectId = getProcessArgValue('comapeo-initial-project-id')
+		let projectId = getProcessArgValue('comapeo-initial-project-id')
 
-		if (projectId === 'undefined') {
-			return undefined
+		if (projectId !== 'undefined') {
+			return projectId
 		}
+
+		// NOTE: Accounts for edge case where a manual reload of the window happens on the first usage of the app.
+		// This is only used in initialization before mounting the rendered app.
+		projectId = ipcRenderer.sendSync('activeProjectId:get')
 
 		return projectId
 	},


### PR DESCRIPTION
Follow-up to #355 . Fixes an issue that's only relevant when using the app for the first time. Can reproduce by doing the following:

1. Open app for first time.
2. Go through onboarding
3. Enter app
4. Manually refresh page e.g. `ctrl + r`

What's happening is that the whole app reloads but the initial window arguments provided when creating the browser window are not recalculated. So after going through the onboarding and having a valid active project ID that's persisted, if you reload the page, we initialized the store value using the stale value that comes from opening the app fresh for the first time (undefined). This issue is not relevant if you close the app after step 3, re-open it, and perform step 4.

Solution is a bit ugly but we provide a fallback IPC call to synchronously get the stored active project ID if the initial window argument is undefined. This allows us to keep the same setup code without potentially exposing more runtime methods that get intermixed in the app loaders.