### PR TITLE
chore: fix release URL interpolation in comment step of relase workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,8 @@ jobs:
     name: Comment
     needs: [create_release, upload_builds]
     runs-on: ubuntu-latest
+    env:
+      RELEASE_URL: ${{ needs.create_release.result.release_url }}
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
@@ -116,7 +118,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          RELEASE_URL: ${{ needs.create_release.result.release_url }}
           COMMENT_BODY: |
             :rocket: A draft release pointing to ${{ github.event.pull_request.merge_commit_sha }} has been created at ${{ env.RELEASE_URL }}
         run: |


### PR DESCRIPTION
Catching an potential issue similar to #352 but for the release comment.