### PR TITLE
chore: fix checkout step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           sparse-checkout: |
             package.json
+            .github/parse-version/action.yml
           sparse-checkout-cone-mode: false
 
       - name: Parse version


### PR DESCRIPTION
Probably fixes the error seen here: https://github.com/digidem/comapeo-desktop/actions/runs/19041969834/job/54381172657