### PR TITLE
Revert "chore: start v1 development iteration"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "comapeo-desktop",
-	"version": "1.1.0-pre",
+	"version": "1.0.0-pre",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "comapeo-desktop",
-			"version": "1.1.0-pre",
+			"version": "1.0.0-pre",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "comapeo-desktop",
 	"productName": "CoMapeo Desktop",
 	"private": true,
-	"version": "1.1.0-pre",
+	"version": "1.0.0-pre",
 	"description": "Desktop application for CoMapeo",
 	"keywords": [],
 	"author": {


### PR DESCRIPTION
This reverts commit 68cdc7c57b044e73ab66518382bb96ff5d9b18d1.

Context is that our release automation for the initial release failed [here](https://github.com/digidem/comapeo-desktop/actions/runs/19041969834/job/54381172657) due to a trivial error. For the sake of having a "clean" first release, plan is to:

1. Merge this PR
2. Delete the `release/v1.x` branch (via temporary override of relevant ruleset)
3. Dispatch another scheduled release, which should create another RC PR similar to #309 