### PR TITLE
fix: prevent entering app for project that you are not a valid member of

### DIFF
--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -75,14 +75,15 @@ const router = createRouter({
 	routeTree,
 	history: hashHistory,
 	context: {
-		queryClient,
 		clientApi,
+		history: hashHistory,
+		queryClient,
 		// NOTE: Populated at render time
 		activeProjectIdStore: undefined!,
 		// NOTE: Populated at render time
-		localeState: undefined!,
-		// NOTE: Populated at render time
 		formatMessage: undefined!,
+		// NOTE: Populated at render time
+		localeState: undefined!,
 	},
 	defaultPreload: 'intent',
 	// Since we're using React Query, we don't want loader calls to ever be stale

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -1,6 +1,10 @@
 import type { MapeoClientApi } from '@comapeo/ipc/client.js'
 import type { QueryClient } from '@tanstack/react-query'
-import { Outlet, createRootRouteWithContext } from '@tanstack/react-router'
+import {
+	Outlet,
+	createRootRouteWithContext,
+	type RouterHistory,
+} from '@tanstack/react-router'
 import type { IntlShape } from 'react-intl'
 
 import type { LocaleState } from '../../../shared/intl'
@@ -9,9 +13,10 @@ import type { ActiveProjectIdStore } from '../contexts/active-project-id-store-c
 export interface RootRouterContext {
 	activeProjectIdStore: ActiveProjectIdStore
 	clientApi: MapeoClientApi
+	formatMessage: IntlShape['formatMessage']
+	history: RouterHistory
 	localeState: LocaleState
 	queryClient: QueryClient
-	formatMessage: IntlShape['formatMessage']
 }
 
 export const Route = createRootRouteWithContext<RootRouterContext>()({


### PR DESCRIPTION
Still occasionally running into situations where we end up trying to access a project-specific page for a project that we no longer have access to. This PR adds a route guard to make sure that we're still a valid member of the project. If we aren't we clear the stale project ID and reload the app at the index, which should elegantly redirect to the appropriate location thereafter.

This doesn't feel like a fix for the root cause, but I'm also not able to reliably reproduce the issue. Guessing there's a race condition related to the active project ID stuff and the best we can do is to try to get rid of potentially bad state automatically.