### PR TITLE
Revert "chore: start v1 development iteration"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "comapeo-desktop",
-	"version": "1.1.0-pre",
+	"version": "1.0.0-pre",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "comapeo-desktop",
-			"version": "1.1.0-pre",
+			"version": "1.0.0-pre",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "comapeo-desktop",
 	"productName": "CoMapeo Desktop",
 	"private": true,
-	"version": "1.1.0-pre",
+	"version": "1.0.0-pre",
 	"description": "Desktop application for CoMapeo",
 	"keywords": [],
 	"author": {


### PR DESCRIPTION
This reverts commit 79b6b48c204a5897c422374e83601bb7a1898cf0.

Another [failed release attempt](https://github.com/digidem/comapeo-desktop/actions/runs/19139200138) 🙃 Resetting things and will fix the issue, then try releasing again.