### PR TITLE
chore: fix reference to parse-version action output in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
-      tag_version: ${{ steps.version.outputs.releaseShort }}
+      tag_name: ${{ steps.version.outputs.releaseShort }}
       release_url: ${{ steps.release.outputs.release_url }}
     steps:
       - name: Create GitHub App Token
@@ -92,7 +92,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
-          TAG_NAME: ${{ needs.create_release.outputs.tag_version }}
+          TAG_NAME: ${{ needs.create_release.outputs.tag_name }}
         run: gh release upload "$TAG_NAME" * --clobber --repo "$REPOSITORY"
 
   comment:


### PR DESCRIPTION
Attempting to release [failed](https://github.com/digidem/comapeo-desktop/actions/runs/19145621972) again. This is the actual fix that #388 intended to fix. We were using the wrong reference to the output from the version parsing step which is why the gh cli was complaining about the lack of a tag.