### PR TITLE
Revert "chore: start v1 development iteration"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "comapeo-desktop",
-	"version": "1.1.0-pre",
+	"version": "1.0.0-pre",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "comapeo-desktop",
-			"version": "1.1.0-pre",
+			"version": "1.0.0-pre",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "comapeo-desktop",
 	"productName": "CoMapeo Desktop",
 	"private": true,
-	"version": "1.1.0-pre",
+	"version": "1.0.0-pre",
 	"description": "Desktop application for CoMapeo",
 	"keywords": [],
 	"author": {


### PR DESCRIPTION
This reverts commit c2c5678988137c255ca1350c8c924a7afd85f75a.

Got further along but ran into a separate [build error](https://github.com/digidem/comapeo-desktop/actions/runs/19147580282/job/54729268217#step:10:439) so redoing this. Also realized a couple of fixes are needed for the tag name extraction.