### PR TITLE
chore: maybe fix issues with production build version on windows

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -359,7 +359,7 @@ export default {
 			// https://www.electronforge.io/config/makers/squirrel.windows#spaces-in-the-app-name
 			name: properties.win32ProductName,
 			exe: `${properties.executableName}.exe`,
-			setupExe: `${properties.executableName}-${properties.appVersion}-win32-${arch}-setup.exe`,
+			setupExe: `${properties.executableName}-${packageJSON.version}-win32-${arch}-setup.exe`,
 			noMsi: true,
 		})),
 		new MakerDMG({ icon: './assets/icon.icns' }),


### PR DESCRIPTION
When attempting to create production builds, was getting the following [failure](https://github.com/digidem/comapeo-desktop/actions/runs/19147580282/job/54729268217#step:10:471) on Windows:

```console
System.Exception: Your package version is currently 0.0, which is *not* SemVer-compatible, change this to be a SemVer version number
```

Not super sure if the changes here will fix it but couldn't really figure out where else it would get the version in our custom format. The `appVersion` that's calculated in our Forge config isn't used as-is when it comes to packaging.

The potential drawback of this change is that the built artifacts will probably have version numbers that match semver instead of our custom version format, which was kind of already an issue anyways for certain platforms (macOS, i think?)