### PR TITLE
chore: reset version and change major version to 0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "comapeo-desktop",
-	"version": "1.0.0-pre",
+	"version": "0.0.0-pre",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "comapeo-desktop",
-			"version": "1.0.0-pre",
+			"version": "0.0.0-pre",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "comapeo-desktop",
 	"productName": "CoMapeo Desktop",
 	"private": true,
-	"version": "1.0.0-pre",
+	"version": "0.0.0-pre",
 	"description": "Desktop application for CoMapeo",
 	"keywords": [],
 	"author": {


### PR DESCRIPTION
Reverts 20df41fec25d4fc32c1e1a38f523db340f110a04.

Also sets the major version to `0` instead of `1`. Context for this is that we have a custom version format that we use in-app that's basically semver without the major version. This isn't compatible with some platform requirements that basically require a semver version to be used. To mitigate the discrepancy between what's shown in the app vs the system, we're changing the major version `1` to a `0`, which is usually easier to ignore and less prone to confusion.

Plan of action for updating the MVP release:

1. Merge this PR
2. Delete the MVP GitHub release and the corresponding git tag
3. Create a new scheduled release