### PR TITLE
chore: replace spaces in built distributable name with underscores

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -428,9 +428,20 @@ export default {
 			const artifacts = makeResults.flatMap((result) => result.artifacts)
 
 			await Promise.all(
-				artifacts.map((a) =>
-					fs.cp(a, path.join(destinationDir, path.basename(a))),
-				),
+				artifacts.map((a) => {
+					const parsedArtifact = path.parse(a)
+
+					let name = parsedArtifact.name
+
+					if (name.includes(' ')) {
+						console.log(`⚠️ Replacing spaces in "${name}" with underscores`)
+						name = name.replaceAll(' ', '_')
+					}
+
+					const basenameToUse = `${name}${parsedArtifact.ext}`
+
+					return fs.cp(a, path.join(destinationDir, basenameToUse))
+				}),
 			)
 		},
 	},


### PR DESCRIPTION
Fixes #399 . This realistically only affects macOS-generated distributables. Note that this does not affect the name of the actual app package that is installed. For example, while the distributable on macOS will be something like `CoMapeo_Desktop-<rest-of-stuff>.dmg`, the installed application name will still be `CoMapeo Desktop.app`