### PR TITLE
fix: fix accidental navigation when hovering on invite devices link in team page

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId_/invite/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/invite/index.tsx
@@ -14,7 +14,7 @@ import { ButtonLink } from '../../../../../components/link'
 import { COMAPEO_CORE_REACT_ROOT_QUERY_KEY } from '../../../../../lib/comapeo'
 
 export const Route = createFileRoute('/app/projects/$projectId/invite/')({
-	loader: async ({ context, params }) => {
+	beforeLoad: async ({ context, params }) => {
 		const { projectApi, queryClient } = context
 		const { projectId } = params
 


### PR DESCRIPTION
There was super strange behavior occurring under the following sequence:

1. Go through invite flow
2. Navigate back to team page
3. **Hover** over `Invite Device` link

After (3), you'd end up on the devices to invite page! Guessing this is an issue or undocumented behavior with Tanstack Router, but not entirely sure. Seems that changing the loader for the relevant page to a beforeLoad fixes the issue, which seems decently appropriate to do anyways.