### PR TITLE
fix: add missing icon to confirmation button when deleting observation attachment

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/attachments/$driveId.$type.$variant.$name.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/attachments/$driveId.$type.$variant.$name.tsx
@@ -580,6 +580,7 @@ function DeleteAttachmentConfirmationDialog({
 						onClick={() => {
 							onConfirm()
 						}}
+						startIcon={<Icon name="material-symbols-delete" />}
 						sx={{ maxWidth: 400 }}
 					>
 						{t(m.deleteAttachmentDialogConfirm)}


### PR DESCRIPTION
Towards #384 . Missed this in #409 

---

Preview:

<img width="600" alt="Screenshot 2025-11-13 at 15 33 21" src="https://github.com/user-attachments/assets/223c24f8-5549-4804-9921-0a3cf02520f0" />