### PR TITLE
feat: add ability to delete an observation

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -261,6 +261,34 @@
     "description": "Text for button to change category.",
     "message": "Change"
   },
+  "routes.app.projects.$projectId.observations.$observationDocId.index.deleteObservationButtonText": {
+    "description": "Text for delete observation button.",
+    "message": "Delete"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.index.deleteObservationConfirmationDialogCancel": {
+    "description": "Text for cancel button of delete observation confirmation dialog.",
+    "message": "Cancel"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.index.deleteObservationConfirmationDialogConfirm": {
+    "description": "Text for confirmation button of delete observation confirmation dialog.",
+    "message": "Yes, Delete"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.index.deleteObservationConfirmationDialogTitle": {
+    "description": "Text for title of delete observation confirmation dialog.",
+    "message": "Delete Observation?"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.index.deleteObservationSuccessPanelReturnToObservations": {
+    "description": "Text for button to return to observations list in successful observation deletion panel.",
+    "message": "Return to Observations List"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.index.deleteObservationSuccessPanelReturnToTrack": {
+    "description": "Text for button to return to track in successful observation deletion panel.",
+    "message": "Return to Track"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.index.deleteObservationSuccessPanelTitle": {
+    "description": "Title text for the successful observation deletion panel.",
+    "message": "Observation Deleted"
+  },
   "routes.app.projects.$projectId.observations.$observationDocId.index.detailsSectionTitle": {
     "description": "Title for details section.",
     "message": "Details"


### PR DESCRIPTION
Towards #384 

Notes:

- only allowed under the following circumstances: you created the observation, or you're a project coordinator
- known issues
  - the automatic map adjustments when the observation is deleted are a bit jarring. think it'd be easier to handle as part of #422 if necessary.
  
---

Preview:

- Details page

    - As someone who can delete the observation

        <img width="600" alt="384-delete-observation-details-coordinator" src="https://github.com/user-attachments/assets/0dda73a0-3ba7-4baf-921b-823877f22085" />
        
    - As someone who cannot delete the observation
    
        <img width="600" alt="384-delete-observation-details-participant" src="https://github.com/user-attachments/assets/39b43d84-364b-44d6-8f63-b13b14d35788" />

- Confirmation dialog

    <img width="600" alt="384-delete-observation-confirmation" src="https://github.com/user-attachments/assets/b2a30ece-8c65-4fc6-b93c-c04ee8e088df" />

- Error dialog

    <img width="600" alt="384-delete-observation-error" src="https://github.com/user-attachments/assets/7dff976d-6fa1-4ba5-93ff-c7c7a8762d77" />

- Success
    
    - When navigated from observations list
    
        <img width="600" alt="384-delete-observation-success" src="https://github.com/user-attachments/assets/0215de19-0c4f-4495-9afa-603d7b0699ab" />
        
    - When navigated from track details
    
        <img width="600" alt="384-delete-observation-success-from-track" src="https://github.com/user-attachments/assets/5266e839-4c2c-4a7e-815d-4754ff34eb12" />
        
- Interaction flow

    https://github.com/user-attachments/assets/8c8ffdd0-a53f-4e31-b264-a2c9def34156


