### PR TITLE
feat: add ability to edit observation details

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -253,6 +253,34 @@
     "description": "Fallback name for observation without a matching category.",
     "message": "Observation"
   },
+  "routes.app.projects.$projectId.observations.$observationDocId.-field-editors.cancelButtonText": {
+    "description": "Text for cancel button.",
+    "message": "Cancel"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.-field-editors.saveButtonText": {
+    "description": "Text for save button.",
+    "message": "Save"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.-field-sections.editNotesTooltip": {
+    "description": "Text for tooltip when hovering over notes.",
+    "message": "Click to Edit"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.-field-sections.fieldAnswerNoAnswer": {
+    "description": "Fallback text displayed if field has no meaningful value.",
+    "message": "No answer"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerFalse": {
+    "description": "Text displayed if a boolean field is answered with \"false\"",
+    "message": "FALSE"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerNull": {
+    "description": "Text displayed if a field is answered with \"null\"",
+    "message": "NULL"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerTrue": {
+    "description": "Text displayed if a boolean field is answered with \"true\"",
+    "message": "TRUE"
+  },
   "routes.app.projects.$projectId.observations.$observationDocId.-notes-section.accessibleNotesInputLabel": {
     "description": "Accessible label for notes input field.",
     "message": "Notes"
@@ -316,22 +344,6 @@
   "routes.app.projects.$projectId.observations.$observationDocId.index.detailsSectionTitle": {
     "description": "Title for details section.",
     "message": "Details"
-  },
-  "routes.app.projects.$projectId.observations.$observationDocId.index.fieldAnswerFalse": {
-    "description": "Text displayed if a boolean field is answered with \"false\"",
-    "message": "FALSE"
-  },
-  "routes.app.projects.$projectId.observations.$observationDocId.index.fieldAnswerNoAnswer": {
-    "description": "Fallback text displayed if field has no meaningful value.",
-    "message": "No answer"
-  },
-  "routes.app.projects.$projectId.observations.$observationDocId.index.fieldAnswerNull": {
-    "description": "Text displayed if a field is answered with \"null\"",
-    "message": "NULL"
-  },
-  "routes.app.projects.$projectId.observations.$observationDocId.index.fieldAnswerTrue": {
-    "description": "Text displayed if a boolean field is answered with \"true\"",
-    "message": "TRUE"
   },
   "routes.app.projects.$projectId.observations.$observationDocId.index.mediaAttachmentsSectionTitle": {
     "description": "Title for media attachments section.",

--- a/src/renderer/src/contexts/global-editing-state-store-context.ts
+++ b/src/renderer/src/contexts/global-editing-state-store-context.ts
@@ -5,18 +5,23 @@ export type GlobalEditingStateStore = ReturnType<
 	typeof createGlobalEditingStateStore
 >
 
-export type GlobalEditingState = boolean
+export type GlobalEditingState = {
+	activeEdits: Array<string>
+}
 
-export function createGlobalEditingStateStore(opts?: {
-	initialValue: GlobalEditingState
-}) {
+export function createGlobalEditingStateStore() {
 	const store = createStore<GlobalEditingState>(() => {
-		return !!opts?.initialValue
+		return { activeEdits: [] }
 	})
 
 	const actions = {
-		update: (value: GlobalEditingState) => {
-			store.setState(value)
+		add: (value: string) => {
+			store.setState((prev) => ({ activeEdits: [...prev.activeEdits, value] }))
+		},
+		remove: (value: string) => {
+			store.setState((prev) => ({
+				activeEdits: prev.activeEdits.filter((e) => e !== value),
+			}))
 		},
 	}
 
@@ -38,9 +43,13 @@ function useGlobalEditingStateStore() {
 	return value
 }
 
-export function useGlobalEditingState(): GlobalEditingState {
+function activeEditsSelector(state: GlobalEditingState) {
+	return state.activeEdits
+}
+
+export function useGlobalEditingState(): GlobalEditingState['activeEdits'] {
 	const store = useGlobalEditingStateStore()
-	return useStore(store.instance)
+	return useStore(store.instance, activeEditsSelector)
 }
 
 export function useGlobalEditingStateActions() {

--- a/src/renderer/src/lib/comapeo.ts
+++ b/src/renderer/src/lib/comapeo.ts
@@ -1,9 +1,13 @@
 import type { MemberApi } from '@comapeo/core'
-import type { Field, Observation, Preset, Track } from '@comapeo/schema'
+import type { Observation, Preset, Track } from '@comapeo/schema'
 
 export type Attachment = Observation['attachments'][number]
 
 export type DeviceType = NonNullable<MemberApi.MemberInfo['deviceType']>
+
+export type ObservationTagValue = Observation['tags'][keyof Observation['tags']]
+export type TrackTagValue = Track['tags'][keyof Track['tags']]
+export type TagValue = ObservationTagValue | TrackTagValue
 
 // https://github.com/digidem/comapeo-core-react/blob/e56979321e91440ad6e291521a9e3ce8eb91200d/src/lib/react-query/shared.ts#L6C1-L6C52
 export const COMAPEO_CORE_REACT_ROOT_QUERY_KEY = '@comapeo/core-react' as const
@@ -91,52 +95,4 @@ export function memberIsActiveRemoteArchive(
 	if (!member.selfHostedServerDetails) return false
 	if (member.role.roleId !== MEMBER_ROLE_ID) return false
 	return true
-}
-
-export function getRenderableFieldInfo({
-	field,
-	tags,
-	answerTypeToTranslatedString,
-}: {
-	field: Field
-	tags: Observation['tags'] | Track['tags']
-	answerTypeToTranslatedString: {
-		true: string
-		false: string
-		null: string
-	}
-}): { label: string; answer: string } {
-	const { label, tagKey } = field
-
-	const correspondingFieldValueFromTags = tags[tagKey]
-
-	const renderedValue = (
-		Array.isArray(correspondingFieldValueFromTags)
-			? correspondingFieldValueFromTags
-			: [correspondingFieldValueFromTags]
-	)
-		// Only keep answers with a meaningful value i.e. no `undefined`, `''` (can happen if an answer is deleted by the user) or whitespace-only strings.
-		.filter((value): value is string | boolean | number | null => {
-			if (typeof value === 'string' && value.trim().length === 0) {
-				return false
-			}
-
-			return value !== undefined
-		})
-		.map((value) => {
-			if (typeof value === 'string' || typeof value === 'number') {
-				return value
-			}
-
-			if (typeof value === 'boolean') {
-				return answerTypeToTranslatedString[value ? 'true' : 'false']
-			}
-
-			if (value === null) {
-				return answerTypeToTranslatedString['null']
-			}
-		})
-		.join(', ')
-
-	return { label, answer: renderedValue }
 }

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-field-editors.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-field-editors.tsx
@@ -1,0 +1,490 @@
+import Button from '@mui/material/Button'
+import Checkbox from '@mui/material/Checkbox'
+import FormControl from '@mui/material/FormControl'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import FormGroup from '@mui/material/FormGroup'
+import Radio from '@mui/material/Radio'
+import RadioGroup from '@mui/material/RadioGroup'
+import Stack from '@mui/material/Stack'
+import { captureException } from '@sentry/react'
+import { defineMessages, useIntl } from 'react-intl'
+import * as v from 'valibot'
+
+import { Icon } from '../../../../../../components/icon'
+import { useAppForm } from '../../../../../../hooks/forms'
+import {
+	getDisplayedTagValue,
+	type EditableMultiSelectField,
+	type EditableNumberField,
+	type EditableSingleSelectField,
+	type EditableTextField,
+} from './shared'
+
+const TextFieldEditorSchema = v.object({
+	answer: v.union([v.undefined(), v.pipe(v.string(), v.trim())]),
+})
+
+export function TextFieldEditor({
+	field,
+	initialValue,
+	onCancel,
+	onSave,
+}: {
+	field: EditableTextField
+	initialValue: string | undefined
+	onCancel: () => void
+	onSave: (value: string | undefined) => Promise<void>
+}) {
+	const { formatMessage: t } = useIntl()
+
+	const form = useAppForm({
+		defaultValues: { answer: initialValue },
+		validators: { onChange: TextFieldEditorSchema },
+		onSubmit: async ({ value }) => {
+			const parsedValue = v.parse(TextFieldEditorSchema, value)
+
+			await onSave(parsedValue.answer)
+		},
+	})
+
+	return (
+		<Stack
+			direction="column"
+			gap={4}
+			component="form"
+			id={`${field.label}-form`}
+			onSubmit={(event) => {
+				event.preventDefault()
+				if (form.state.isSubmitting) return
+				form.handleSubmit().catch((err) => {
+					captureException(err)
+				})
+			}}
+		>
+			<form.AppField name="answer">
+				{(formField) => (
+					<formField.TextField
+						fullWidth
+						multiline={field.appearance !== 'singleline'}
+						aria-label={field.label}
+						autoFocus
+						onFocus={(event) => {
+							if (formField.state.value) {
+								event.target.setSelectionRange(
+									formField.state.value.length,
+									formField.state.value.length,
+								)
+							}
+						}}
+						value={formField.state.value}
+						error={!formField.state.meta.isValid}
+						name={formField.name}
+						onChange={(event) => {
+							formField.handleChange(event.target.value)
+						}}
+						onBlur={formField.handleBlur}
+					/>
+				)}
+			</form.AppField>
+
+			<Stack direction="row" justifyContent="space-between" gap={2}>
+				<form.Subscribe selector={(state) => state.isSubmitting}>
+					{(isSubmitting) => (
+						<>
+							<form.SubmitButton
+								type="submit"
+								fullWidth
+								sx={{ maxWidth: 400 }}
+								loadingPosition="start"
+								loading={isSubmitting}
+								endIcon={<Icon name="material-check-circle-outline-rounded" />}
+							>
+								{t(m.saveButtonText)}
+							</form.SubmitButton>
+
+							<Button
+								type="button"
+								variant="outlined"
+								fullWidth
+								sx={{ maxWidth: 400 }}
+								onClick={() => {
+									if (isSubmitting) {
+										return
+									}
+
+									onCancel()
+								}}
+							>
+								{t(m.cancelButtonText)}
+							</Button>
+						</>
+					)}
+				</form.Subscribe>
+			</Stack>
+		</Stack>
+	)
+}
+
+const NumberFieldEditorSchema = v.object({
+	answer: v.union([
+		v.undefined(),
+		v.pipe(
+			v.string(),
+			v.minLength(1),
+			v.trim(),
+			v.digits(),
+			v.transform((value) => {
+				return Number(value)
+			}),
+		),
+	]),
+})
+
+export function NumberFieldEditor({
+	field,
+	initialValue,
+	onCancel,
+	onSave,
+}: {
+	field: EditableNumberField
+	initialValue: number | undefined
+	onCancel: () => void
+	onSave: (value: number | undefined) => Promise<void>
+}) {
+	const { formatMessage: t } = useIntl()
+
+	const form = useAppForm({
+		defaultValues: { answer: initialValue?.toString() },
+		validators: { onChange: NumberFieldEditorSchema },
+		onSubmit: async ({ value }) => {
+			const parsedValue = v.parse(NumberFieldEditorSchema, value)
+			await onSave(parsedValue.answer)
+		},
+	})
+
+	return (
+		<Stack
+			direction="column"
+			gap={4}
+			component="form"
+			id={`${field.label}-form`}
+			onSubmit={(event) => {
+				event.preventDefault()
+				if (form.state.isSubmitting) return
+				form.handleSubmit().catch((err) => {
+					captureException(err)
+				})
+			}}
+		>
+			<form.AppField name="answer">
+				{(formField) => (
+					<formField.TextField
+						fullWidth
+						aria-label={field.label}
+						autoFocus
+						onFocus={(event) => {
+							if (formField.state.value) {
+								event.target.setSelectionRange(
+									formField.state.value.length,
+									formField.state.value.length,
+								)
+							}
+						}}
+						value={formField.state.value}
+						error={!formField.state.meta.isValid}
+						name={formField.name}
+						onBlur={formField.handleBlur}
+						inputMode="numeric"
+						onChange={(event) => {
+							if (
+								event.target.value === '' ||
+								v.is(v.pipe(v.string(), v.digits()), event.target.value)
+							) {
+								formField.handleChange(event.target.value)
+							}
+						}}
+					/>
+				)}
+			</form.AppField>
+
+			<Stack direction="row" justifyContent="space-between" gap={2}>
+				<form.Subscribe selector={(state) => state.isSubmitting}>
+					{(isSubmitting) => (
+						<>
+							<form.SubmitButton
+								type="submit"
+								fullWidth
+								sx={{ maxWidth: 400 }}
+								loadingPosition="start"
+								loading={isSubmitting}
+								endIcon={<Icon name="material-check-circle-outline-rounded" />}
+							>
+								{t(m.saveButtonText)}
+							</form.SubmitButton>
+
+							<Button
+								type="button"
+								variant="outlined"
+								fullWidth
+								sx={{ maxWidth: 400 }}
+								onClick={() => {
+									if (isSubmitting) {
+										return
+									}
+
+									onCancel()
+								}}
+							>
+								{t(m.cancelButtonText)}
+							</Button>
+						</>
+					)}
+				</form.Subscribe>
+			</Stack>
+		</Stack>
+	)
+}
+
+export function SingleSelectFieldEditor({
+	field,
+	initialValue,
+	onCancel,
+	onSave,
+}: {
+	field: EditableSingleSelectField
+	initialValue: string | boolean | number | null | undefined
+	onCancel: () => void
+	onSave: (value: string | boolean | number | null | undefined) => Promise<void>
+}) {
+	const { formatMessage: t } = useIntl()
+
+	const form = useAppForm({
+		defaultValues: { answer: initialValue },
+		onSubmit: async ({ value }) => {
+			await onSave(value.answer)
+		},
+	})
+
+	return (
+		<Stack
+			direction="column"
+			gap={4}
+			component="form"
+			id={`${field.label}-form`}
+			onSubmit={(event) => {
+				event.preventDefault()
+				if (form.state.isSubmitting) return
+				form.handleSubmit().catch((err) => {
+					captureException(err)
+				})
+			}}
+		>
+			<form.AppField name="answer">
+				{(formField) => {
+					const shouldShowOptionForInitialValue =
+						initialValue !== undefined &&
+						!(
+							typeof initialValue === 'string' &&
+							initialValue.trim().length === 0
+						) &&
+						!field.options.some((o) => o.value === initialValue)
+
+					return (
+						<FormControl>
+							<RadioGroup>
+								{shouldShowOptionForInitialValue ? (
+									<FormControlLabel
+										value={initialValue}
+										checked={formField.state.value === initialValue}
+										onChange={(event) => {
+											formField.handleChange(
+												(event.target as HTMLInputElement).value,
+											)
+										}}
+										onBlur={formField.handleBlur}
+										control={<Radio />}
+										label={getDisplayedTagValue({
+											tagValue: initialValue,
+											formatMessage: t,
+										})}
+									/>
+								) : null}
+
+								{field.options.map((option) => (
+									<FormControlLabel
+										key={option.label}
+										value={option.value}
+										checked={formField.state.value === option.value}
+										onChange={(event) => {
+											formField.handleChange(
+												(event.target as HTMLInputElement).value,
+											)
+										}}
+										onBlur={formField.handleBlur}
+										control={<Radio />}
+										label={option.label}
+									/>
+								))}
+							</RadioGroup>
+						</FormControl>
+					)
+				}}
+			</form.AppField>
+
+			<Stack direction="row" justifyContent="space-between" gap={2}>
+				<form.Subscribe selector={(state) => state.isSubmitting}>
+					{(isSubmitting) => (
+						<>
+							<form.SubmitButton
+								type="submit"
+								fullWidth
+								sx={{ maxWidth: 400 }}
+								loadingPosition="start"
+								loading={isSubmitting}
+								endIcon={<Icon name="material-check-circle-outline-rounded" />}
+							>
+								{t(m.saveButtonText)}
+							</form.SubmitButton>
+
+							<Button
+								type="button"
+								variant="outlined"
+								fullWidth
+								sx={{ maxWidth: 400 }}
+								onClick={() => {
+									if (isSubmitting) {
+										return
+									}
+
+									onCancel()
+								}}
+							>
+								{t(m.cancelButtonText)}
+							</Button>
+						</>
+					)}
+				</form.Subscribe>
+			</Stack>
+		</Stack>
+	)
+}
+
+export function MultiSelectFieldEditor({
+	field,
+	initialValue,
+	onCancel,
+	onSave,
+}: {
+	field: EditableMultiSelectField
+	initialValue: Array<string | boolean | number | null>
+	onCancel: () => void
+	onSave: (value: Array<string | boolean | number | null>) => Promise<void>
+}) {
+	const { formatMessage: t } = useIntl()
+
+	const defaultValues: Record<string, boolean> = {}
+
+	for (const option of field.options) {
+		const selected = initialValue.includes(option.value)
+		defaultValues[option.label] = selected
+	}
+
+	const form = useAppForm({
+		defaultValues,
+		onSubmit: async ({ value }) => {
+			const answers = []
+
+			for (const [label, checked] of Object.entries(value)) {
+				if (checked) {
+					answers.push(field.options.find((o) => o.label === label)!.value)
+				}
+			}
+
+			await onSave(answers)
+		},
+	})
+
+	return (
+		<Stack
+			direction="column"
+			gap={4}
+			component="form"
+			id={`${field.label}-form`}
+			onSubmit={(event) => {
+				event.preventDefault()
+				if (form.state.isSubmitting) return
+				form.handleSubmit().catch((err) => {
+					captureException(err)
+				})
+			}}
+		>
+			<FormGroup>
+				{field.options.map((option) => (
+					<form.AppField name={option.label} key={option.label}>
+						{(formField) => (
+							<FormControlLabel
+								key={option.label}
+								value={option.value}
+								checked={formField.state.value}
+								onChange={(_event, checked) => {
+									formField.handleChange(checked)
+								}}
+								onBlur={formField.handleBlur}
+								control={<Checkbox />}
+								label={option.label}
+							/>
+						)}
+					</form.AppField>
+				))}
+			</FormGroup>
+
+			<Stack direction="row" justifyContent="space-between" gap={2}>
+				<form.Subscribe selector={(state) => state.isSubmitting}>
+					{(isSubmitting) => (
+						<>
+							<form.SubmitButton
+								type="submit"
+								fullWidth
+								sx={{ maxWidth: 400 }}
+								loadingPosition="start"
+								loading={isSubmitting}
+								endIcon={<Icon name="material-check-circle-outline-rounded" />}
+							>
+								{t(m.saveButtonText)}
+							</form.SubmitButton>
+
+							<Button
+								type="button"
+								variant="outlined"
+								fullWidth
+								sx={{ maxWidth: 400 }}
+								onClick={() => {
+									if (isSubmitting) {
+										return
+									}
+
+									onCancel()
+								}}
+							>
+								{t(m.cancelButtonText)}
+							</Button>
+						</>
+					)}
+				</form.Subscribe>
+			</Stack>
+		</Stack>
+	)
+}
+
+const m = defineMessages({
+	saveButtonText: {
+		id: 'routes.app.projects.$projectId.observations.$observationDocId.-field-editors.saveButtonText',
+		defaultMessage: 'Save',
+		description: 'Text for save button.',
+	},
+	cancelButtonText: {
+		id: 'routes.app.projects.$projectId.observations.$observationDocId.-field-editors.cancelButtonText',
+		defaultMessage: 'Cancel',
+		description: 'Text for cancel button.',
+	},
+})

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-field-sections.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-field-sections.tsx
@@ -1,0 +1,316 @@
+import { useSingleDocByDocId, useUpdateDocument } from '@comapeo/core-react'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query'
+import { defineMessages, useIntl } from 'react-intl'
+
+import { ErrorDialog } from '../../../../../../components/error-dialog'
+import {
+	type ObservationTagValue,
+	type TagValue,
+} from '../../../../../../lib/comapeo'
+import { getLocaleStateQueryOptions } from '../../../../../../lib/queries/app-settings'
+import { createGlobalMutationsKey } from '../../../../../../lib/queries/global-mutations'
+import { EditableSection } from './-components/editable-section'
+import {
+	MultiSelectFieldEditor,
+	NumberFieldEditor,
+	SingleSelectFieldEditor,
+	TextFieldEditor,
+} from './-field-editors'
+import { getDisplayedTagValue, type EditableField } from './shared'
+
+export function ReadOnlyFieldSection({
+	label,
+	value,
+}: {
+	label: string
+	value: string | undefined
+}) {
+	const { formatMessage: t } = useIntl()
+
+	return (
+		<Stack direction="column" gap={2}>
+			<Typography component="h3" variant="body1" fontWeight={450}>
+				{label}
+			</Typography>
+
+			<Box padding={2}>
+				<Typography fontStyle={value ? undefined : 'italic'}>
+					{value || t(m.fieldAnswerNoAnswer)}
+				</Typography>
+			</Box>
+		</Stack>
+	)
+}
+
+export function EditableFieldSection({
+	disabled,
+	field,
+	initialTagValue,
+	observationDocId,
+	onStartEditMode,
+	onStopEditMode,
+	projectId,
+}: {
+	disabled?: boolean
+	field: EditableField
+	initialTagValue: TagValue | undefined
+	observationDocId: string
+	onStartEditMode: () => void
+	onStopEditMode: () => void
+	projectId: string
+}) {
+	const { formatMessage: t } = useIntl()
+
+	const { data: lang } = useSuspenseQuery({
+		...getLocaleStateQueryOptions(),
+		select: ({ value }) => value,
+	})
+
+	const { data: observation, isRefetching: observationsIsRefetching } =
+		useSingleDocByDocId({
+			projectId,
+			docId: observationDocId,
+			docType: 'observation',
+			lang,
+		})
+
+	const updateObservationDocument = useUpdateDocument({
+		projectId,
+		docType: 'observation',
+	})
+
+	const updateObservationFieldMutationKey = createGlobalMutationsKey([
+		'observations',
+		observationDocId,
+		'edit',
+		'fields',
+		field.docId,
+		'update',
+	])
+
+	const updateObservationField = useMutation({
+		mutationKey: updateObservationFieldMutationKey,
+		mutationFn: async ({ value }: { value: ObservationTagValue }) => {
+			return updateObservationDocument.mutateAsync({
+				versionId: observation.versionId,
+				value: {
+					...observation,
+					tags: { ...observation.tags, [field.tagKey]: value },
+				},
+			})
+		},
+	})
+
+	const displayedReadOnlyTagValue =
+		initialTagValue === undefined
+			? undefined
+			: getDisplayedTagValue({
+					tagValue: initialTagValue,
+					formatMessage: t,
+					selectionOptions:
+						field.type === 'selectOne' || field.type === 'selectMultiple'
+							? field.options
+							: undefined,
+				})
+
+	return (
+		<>
+			<EditableSection
+				disabled={disabled}
+				onStartEditMode={onStartEditMode}
+				editIsPending={updateObservationField.status === 'pending'}
+				renderWhenEditing={({ updateEditState }) => {
+					function onCancel() {
+						updateEditState('idle')
+						onStopEditMode()
+					}
+
+					switch (field.type) {
+						case 'text': {
+							if (
+								initialTagValue !== undefined &&
+								typeof initialTagValue !== 'string'
+							) {
+								throw new Error(
+									`Expected string type for initial tag value. Received ${typeof initialTagValue}`,
+								)
+							}
+
+							return (
+								<TextFieldEditor
+									field={field}
+									onCancel={onCancel}
+									initialValue={initialTagValue}
+									onSave={async (value) => {
+										updateEditState('idle')
+
+										try {
+											if (value !== undefined) {
+												await updateObservationField.mutateAsync({ value })
+											}
+											updateEditState('success')
+										} finally {
+											onStopEditMode()
+										}
+									}}
+								/>
+							)
+						}
+						case 'number': {
+							if (
+								initialTagValue !== undefined &&
+								typeof initialTagValue !== 'number'
+							) {
+								throw new Error(
+									`Expected number type for initial tag value. Received ${typeof initialTagValue}`,
+								)
+							}
+
+							return (
+								<NumberFieldEditor
+									field={field}
+									initialValue={initialTagValue}
+									onCancel={onCancel}
+									onSave={async (value) => {
+										updateEditState('idle')
+
+										try {
+											if (value !== undefined) {
+												await updateObservationField.mutateAsync({ value })
+											}
+											updateEditState('success')
+										} finally {
+											onStopEditMode()
+										}
+									}}
+								/>
+							)
+						}
+						case 'selectOne': {
+							if (
+								initialTagValue !== undefined &&
+								Array.isArray(initialTagValue)
+							) {
+								throw new Error(
+									'Expected non-array type for initial tag value.',
+								)
+							}
+
+							return (
+								<SingleSelectFieldEditor
+									field={field}
+									initialValue={initialTagValue}
+									onCancel={onCancel}
+									onSave={async (value) => {
+										updateEditState('idle')
+
+										try {
+											if (value !== undefined) {
+												await updateObservationField.mutateAsync({ value })
+											}
+											updateEditState('success')
+										} finally {
+											onStopEditMode()
+										}
+									}}
+								/>
+							)
+						}
+						case 'selectMultiple': {
+							if (
+								initialTagValue !== undefined &&
+								!Array.isArray(initialTagValue)
+							) {
+								throw new Error(
+									`Expected array value for initial tag value. Received ${typeof initialTagValue}`,
+								)
+							}
+
+							return (
+								<MultiSelectFieldEditor
+									field={field}
+									initialValue={
+										initialTagValue === undefined ? [] : initialTagValue
+									}
+									onCancel={onCancel}
+									onSave={async (value) => {
+										updateEditState('idle')
+
+										try {
+											await updateObservationField.mutateAsync({ value })
+											updateEditState('success')
+										} finally {
+											onStopEditMode()
+										}
+									}}
+								/>
+							)
+						}
+					}
+				}}
+				sectionTitle={
+					<Typography component="span" variant="inherit" fontWeight={450}>
+						{field.label}
+					</Typography>
+				}
+				tooltipText={t(m.editNotesTooltip)}
+				renderWhenIdle={() => {
+					if (
+						updateObservationField.status === 'pending' ||
+						(updateObservationField.status === 'success' &&
+							observationsIsRefetching)
+					) {
+						const displayedVariableValue = getDisplayedTagValue({
+							tagValue: updateObservationField.variables.value,
+							formatMessage: t,
+							selectionOptions:
+								field.type === 'selectOne' || field.type === 'selectMultiple'
+									? field.options
+									: undefined,
+						})
+
+						return (
+							<Typography
+								fontStyle={displayedVariableValue ? undefined : 'italic'}
+							>
+								{displayedVariableValue || t(m.fieldAnswerNoAnswer)}
+							</Typography>
+						)
+					}
+
+					return (
+						<Typography
+							fontStyle={displayedReadOnlyTagValue ? undefined : 'italic'}
+						>
+							{displayedReadOnlyTagValue || t(m.fieldAnswerNoAnswer)}
+						</Typography>
+					)
+				}}
+			/>
+
+			<ErrorDialog
+				open={updateObservationField.status === 'error'}
+				errorMessage={updateObservationField.error?.toString()}
+				onClose={() => {
+					updateObservationField.reset()
+				}}
+			/>
+		</>
+	)
+}
+
+const m = defineMessages({
+	fieldAnswerNoAnswer: {
+		id: 'routes.app.projects.$projectId.observations.$observationDocId.-field-sections.fieldAnswerNoAnswer',
+		defaultMessage: 'No answer',
+		description: 'Fallback text displayed if field has no meaningful value.',
+	},
+	editNotesTooltip: {
+		id: 'routes.app.projects.$projectId.observations.$observationDocId.-field-sections.editNotesTooltip',
+		defaultMessage: 'Click to Edit',
+		description: 'Text for tooltip when hovering over notes.',
+	},
+})

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/shared.ts
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/shared.ts
@@ -1,0 +1,89 @@
+import type { Field } from '@comapeo/schema'
+import { defineMessages, type IntlShape } from 'react-intl'
+
+import type { TagValue } from '../../../../../../lib/comapeo'
+
+export type EditableTextField = Field & {
+	type: 'text'
+}
+
+export type EditableNumberField = Field & {
+	type: 'number'
+}
+
+export type EditableSingleSelectField = Field & {
+	type: 'selectOne'
+	options: NonNullable<Field['options']>
+}
+
+export type EditableMultiSelectField = Field & {
+	type: 'selectMultiple'
+	options: NonNullable<Field['options']>
+}
+
+export type EditableField =
+	| EditableTextField
+	| EditableNumberField
+	| EditableSingleSelectField
+	| EditableMultiSelectField
+
+export function getDisplayedTagValue({
+	tagValue,
+	selectionOptions,
+	formatMessage,
+}: {
+	tagValue: TagValue
+	formatMessage: IntlShape['formatMessage']
+	selectionOptions?: NonNullable<Field['options']>
+}): string {
+	return (
+		(Array.isArray(tagValue) ? tagValue : [tagValue])
+			// Only keep string answers with a meaningful value i.e. no `''` (can happen if an answer is deleted by the user) or whitespace-only strings.
+			.filter((v) => {
+				if (typeof v === 'string' && v.trim().length === 0) {
+					return false
+				}
+
+				return true
+			})
+			.map((v) => {
+				if (selectionOptions) {
+					const matchingLabel = selectionOptions.find(
+						(o) => o.value === v,
+					)?.label
+
+					if (matchingLabel) {
+						return matchingLabel
+					}
+				}
+				if (v === null) {
+					return formatMessage(m.fieldAnswerNull)
+				}
+
+				if (typeof v === 'boolean') {
+					return formatMessage(v ? m.fieldAnswerTrue : m.fieldAnswerFalse)
+				}
+
+				return v
+			})
+			.join(', ')
+	)
+}
+
+const m = defineMessages({
+	fieldAnswerTrue: {
+		id: 'routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerTrue',
+		defaultMessage: 'TRUE',
+		description: 'Text displayed if a boolean field is answered with "true"',
+	},
+	fieldAnswerFalse: {
+		id: 'routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerFalse',
+		defaultMessage: 'FALSE',
+		description: 'Text displayed if a boolean field is answered with "false"',
+	},
+	fieldAnswerNull: {
+		id: 'routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerNull',
+		defaultMessage: 'NULL',
+		description: 'Text displayed if a field is answered with "null"',
+	},
+})

--- a/src/renderer/src/routes/app/route.tsx
+++ b/src/renderer/src/routes/app/route.tsx
@@ -137,7 +137,7 @@ function RouteComponent() {
 		currentRoute.routeId ===
 			'/app/projects/$projectId/invite/devices/$deviceId/send'
 
-	const isEditing = useGlobalEditingState()
+	const isEditing = useGlobalEditingState().length > 0
 
 	const someGlobalMutationIsPending =
 		useIsMutating({ mutationKey: GLOBAL_MUTATIONS_BASE_KEY }) > 0


### PR DESCRIPTION
Closes #384 

Notable differences:

- slight indentation for detail answers
- heavier font weight for detail labels
- known bug where an saving an answer for a field that used to have an unanswered field results in the success checkmark only displaying momentarily instead of the 5 seconds
- usage of checkboxes for field types that allow selecting multiple choices
- usage of radios for field types that allow selecting a single choice

---

- Lacking permission to edit

    <img width="600" alt="384-edit-observation-details-cannot-edit" src="https://github.com/user-attachments/assets/ffafd772-9b19-4808-9797-5548ee1c7695" />

- Idle state
 
    <img width="600" alt="384-edit-observation-details-idle" src="https://github.com/user-attachments/assets/bd55bb95-e327-499e-9719-ebc268270632" />

- Hover + focus state

    <img width="600" alt="384-edit-observation-details-hover-or-focus" src="https://github.com/user-attachments/assets/efcf3765-9adc-4ad3-b82d-3b10ed40404b" />

- Text field edit

    <img width="600" alt="384-edit-observation-details-text" src="https://github.com/user-attachments/assets/4099212b-06fd-4465-8434-e5f0fc130c52" />

- Number field edit

    _No preview available since the current default categories don't have any that use this. Works similarly to the text field edit though._

- Select single edit

    <img width="600" alt="384-edit-observation-details-select-single" src="https://github.com/user-attachments/assets/0769c646-3bdf-4ac4-b4a8-15e37f9be342" />

- Select multiple edit

    <img width="600" alt="384-edit-observation-details-select-multiple" src="https://github.com/user-attachments/assets/50aeb76e-b17e-4622-86bb-215e61870258" />

- User interaction flow

    https://github.com/user-attachments/assets/09c29d4a-f189-4e31-b560-59e5e7595a30


