### PR TITLE
fix: minor UI adjustments to observation details page

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -345,7 +345,7 @@
     "description": "Title for details section.",
     "message": "Details"
   },
-  "routes.app.projects.$projectId.observations.$observationDocId.index.locationPlusMinus": {
+  "routes.app.projects.$projectId.observations.$observationDocId.index.locationAccuracy": {
     "description": "Displayed accuracy for observation location in meters.",
     "message": "± {value}m"
   },

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/index.tsx
@@ -575,7 +575,7 @@ function ObservationDetailsPanel({
 											{typeof observation.metadata?.position?.coords
 												.accuracy === 'number' ? (
 												<Box component="span" marginInlineStart={4}>
-													{t(m.locationPlusMinus, {
+													{t(m.locationAccuracy, {
 														value:
 															observation.metadata?.position?.coords.accuracy.toFixed(
 																0,
@@ -1126,8 +1126,8 @@ const m = defineMessages({
 		description:
 			'Text for button to return to track in successful observation deletion panel.',
 	},
-	locationPlusMinus: {
-		id: 'routes.app.projects.$projectId.observations.$observationDocId.index.locationPlusMinus',
+	locationAccuracy: {
+		id: 'routes.app.projects.$projectId.observations.$observationDocId.index.locationAccuracy',
 		defaultMessage: '± {value}m',
 		description: 'Displayed accuracy for observation location in meters.',
 	},


### PR DESCRIPTION
A couple of updates to the UI for the observation details page based on designs from #384 (not explicitly related to that issue though):

- display the location accuracy if available
- switch the placement of the notes section and the attachments section
- add horizontal rules above and below the notes section

---

<img width="600" alt="image" src="https://github.com/user-attachments/assets/143cd14e-fc57-4489-8579-5de9e19ed9f4" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/54b25997-b2cd-48a9-84ee-7d3b641180b3" />
