### PR TITLE
chore: fix warnings caused by misnamed file

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -239,18 +239,6 @@
     "description": "Fallback text displayed if field has no meaningful value.",
     "message": "No answer"
   },
-  "routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerFalse": {
-    "description": "Text displayed if a boolean field is answered with \"false\"",
-    "message": "FALSE"
-  },
-  "routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerNull": {
-    "description": "Text displayed if a field is answered with \"null\"",
-    "message": "NULL"
-  },
-  "routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerTrue": {
-    "description": "Text displayed if a boolean field is answered with \"true\"",
-    "message": "TRUE"
-  },
   "routes.app.projects.$projectId.observations.$observationDocId.-notes-section.accessibleNotesInputLabel": {
     "description": "Accessible label for notes input field.",
     "message": "Notes"
@@ -274,6 +262,18 @@
   "routes.app.projects.$projectId.observations.$observationDocId.-notes-section.title": {
     "description": "Title for notes section.",
     "message": "Notes"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.-shared.fieldAnswerFalse": {
+    "description": "Text displayed if a boolean field is answered with \"false\"",
+    "message": "FALSE"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.-shared.fieldAnswerNull": {
+    "description": "Text displayed if a field is answered with \"null\"",
+    "message": "NULL"
+  },
+  "routes.app.projects.$projectId.observations.$observationDocId.-shared.fieldAnswerTrue": {
+    "description": "Text displayed if a boolean field is answered with \"true\"",
+    "message": "TRUE"
   },
   "routes.app.projects.$projectId.observations.$observationDocId.index.categoryIconAlt": {
     "description": "Alt text for icon image displayed for category (used for accessibility tools).",

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-field-editors.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-field-editors.tsx
@@ -18,7 +18,7 @@ import {
 	type EditableNumberField,
 	type EditableSingleSelectField,
 	type EditableTextField,
-} from './shared'
+} from './-shared'
 
 const TextFieldEditorSchema = v.object({
 	answer: v.union([v.undefined(), v.pipe(v.string(), v.trim())]),

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-field-sections.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-field-sections.tsx
@@ -19,7 +19,7 @@ import {
 	SingleSelectFieldEditor,
 	TextFieldEditor,
 } from './-field-editors'
-import { getDisplayedTagValue, type EditableField } from './shared'
+import { getDisplayedTagValue, type EditableField } from './-shared'
 
 export function ReadOnlyFieldSection({
 	label,

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-shared.ts
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-shared.ts
@@ -72,17 +72,17 @@ export function getDisplayedTagValue({
 
 const m = defineMessages({
 	fieldAnswerTrue: {
-		id: 'routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerTrue',
+		id: 'routes.app.projects.$projectId.observations.$observationDocId.-shared.fieldAnswerTrue',
 		defaultMessage: 'TRUE',
 		description: 'Text displayed if a boolean field is answered with "true"',
 	},
 	fieldAnswerFalse: {
-		id: 'routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerFalse',
+		id: 'routes.app.projects.$projectId.observations.$observationDocId.-shared.fieldAnswerFalse',
 		defaultMessage: 'FALSE',
 		description: 'Text displayed if a boolean field is answered with "false"',
 	},
 	fieldAnswerNull: {
-		id: 'routes.app.projects.$projectId.observations.$observationDocId.-fields.shared.fieldAnswerNull',
+		id: 'routes.app.projects.$projectId.observations.$observationDocId.-shared.fieldAnswerNull',
 		defaultMessage: 'NULL',
 		description: 'Text displayed if a field is answered with "null"',
 	},

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/index.tsx
@@ -60,7 +60,7 @@ import {
 	ObservationAttachmentPending,
 	ObservationAttachmentPreview,
 } from './-observation-attachment'
-import { getDisplayedTagValue, type EditableField } from './shared'
+import { getDisplayedTagValue, type EditableField } from './-shared'
 
 const SearchParamsSchema = v.object({
 	fromTrackDocId: v.optional(v.string()),


### PR DESCRIPTION
I misnamed the file such that tanstack router wasn't ignoring it, causing a build warning about the file not haveing route-related exports.