### PR TITLE
fix: load attachment images more reliably

### DIFF
--- a/src/renderer/src/lib/comapeo.ts
+++ b/src/renderer/src/lib/comapeo.ts
@@ -1,7 +1,30 @@
-import type { MemberApi } from '@comapeo/core'
+import type { BlobApi, MemberApi } from '@comapeo/core'
 import type { Observation, Preset, Track } from '@comapeo/schema'
 
 export type Attachment = Observation['attachments'][number]
+
+export type PhotoAttachment = Extract<Attachment, { type: 'photo' }>
+export type AudioAttachment = Omit<Attachment, 'type'> & { type: 'audio' }
+
+export type PhotoAttachmentVariant = Extract<
+	BlobApi.BlobId,
+	{ type: 'photo' }
+>['variant']
+export type AudioAttachmentVariant = Extract<
+	BlobApi.BlobId,
+	{ type: 'audio' }
+>['variant']
+
+export function isPhotoAttachment(
+	attachment: Attachment,
+): attachment is PhotoAttachment {
+	return attachment.type === 'photo'
+}
+export function isAudioAttachment(
+	attachment: Attachment,
+): attachment is AudioAttachment {
+	return attachment.type === 'audio'
+}
 
 export type DeviceType = NonNullable<MemberApi.MemberInfo['deviceType']>
 

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-components/photo-attachment-image.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-components/photo-attachment-image.tsx
@@ -1,29 +1,37 @@
 import { use } from 'react'
 import { useAttachmentUrl } from '@comapeo/core-react'
 
-import { SuspenseImage } from '../../../../../../../components/suspense-image'
+import {
+	SuspenseImage,
+	type SuspenseImageProps,
+} from '../../../../../../../components/suspense-image'
+import type { PhotoAttachmentVariant } from '../../../../../../../lib/comapeo.ts'
 import { imageSrcResource } from '../../../../../../../lib/image'
 
 export function PhotoAttachmentImage({
 	attachmentDriveId,
 	attachmentName,
+	attachmentVariant,
 	projectId,
+	style,
 }: {
 	attachmentDriveId: string
 	attachmentName: string
+	attachmentVariant: PhotoAttachmentVariant
 	projectId: string
+	style?: SuspenseImageProps['style']
 }) {
 	const { data: url } = useAttachmentUrl({
 		projectId,
 		blobId: {
 			driveId: attachmentDriveId,
 			name: attachmentName,
-			variant: 'original',
+			variant: attachmentVariant,
 			type: 'photo',
 		},
 	})
 
 	const src = use(imageSrcResource(url))
 
-	return <SuspenseImage src={src} style={{ objectFit: 'cover' }} />
+	return <SuspenseImage src={src} style={{ objectFit: 'cover', ...style }} />
 }

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-observation-attachment.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-observation-attachment.tsx
@@ -1,6 +1,5 @@
 import { use } from 'react'
 import { useAttachmentUrl } from '@comapeo/core-react'
-import type { Attachment } from '@comapeo/core/dist/types'
 import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
@@ -11,6 +10,12 @@ import type { SxProps } from '@mui/material/styles'
 import { BLUE_GREY, DARK_GREY } from '../../../../../../colors'
 import { Icon } from '../../../../../../components/icon'
 import { IconButtonLink } from '../../../../../../components/link'
+import type {
+	AudioAttachment,
+	AudioAttachmentVariant,
+	PhotoAttachment,
+	PhotoAttachmentVariant,
+} from '../../../../../../lib/comapeo.ts'
 import { audioInfoResource } from '../../../../../../lib/resources/audio'
 import { getFormattedDuration } from '../../../../../../lib/time'
 import { ImageButtonLink } from './-components/image-button-link'
@@ -29,89 +34,103 @@ const BASE_ATTACHMENT_CONTAINER_STYLE: SxProps = {
 	aspectRatio: 1,
 }
 
-export function ObservationAttachmentPreview({
+export function ObservationPhotoAttachmentPreview({
 	attachment,
 	projectId,
+	variant,
 }: {
-	attachment: Attachment
+	attachment: PhotoAttachment
 	projectId: string
+	variant: PhotoAttachmentVariant
 }) {
-	switch (attachment.type) {
-		case 'photo': {
-			return (
-				<ImageButtonLink
-					height={128}
-					borderColor={BLUE_GREY}
-					to="/app/projects/$projectId/observations/$observationDocId/attachments/$driveId/$type/$variant/$name"
-					params={(prev) => ({
-						...prev,
-						driveId: attachment.driveDiscoveryId,
-						type: 'photo' as const,
-						variant: 'original' as const,
-						name: attachment.name,
-					})}
-				>
-					<PhotoAttachmentImage
-						attachmentDriveId={attachment.driveDiscoveryId}
-						attachmentName={attachment.name}
-						projectId={projectId}
-					/>
-				</ImageButtonLink>
-			)
-		}
-		case 'audio': {
-			return (
-				<IconButtonLink
-					sx={BASE_ATTACHMENT_CONTAINER_STYLE}
-					to="/app/projects/$projectId/observations/$observationDocId/attachments/$driveId/$type/$variant/$name"
-					params={(prev) => ({
-						...prev,
-						driveId: attachment.driveDiscoveryId,
-						type: 'audio' as const,
-						variant: 'original' as const,
-						name: attachment.name,
-					})}
-				>
-					<Stack
-						direction="column"
-						gap={2}
-						justifyContent="center"
-						alignItems="center"
-					>
-						<Icon name="material-volume-up" htmlColor={DARK_GREY} />
+	return (
+		<ImageButtonLink
+			height={128}
+			borderColor={BLUE_GREY}
+			to="/app/projects/$projectId/observations/$observationDocId/attachments/$driveId/$type/$variant/$name"
+			params={(prev) => ({
+				...prev,
+				driveId: attachment.driveDiscoveryId,
+				type: 'photo' as const,
+				variant,
+				name: attachment.name,
+			})}
+		>
+			<PhotoAttachmentImage
+				attachmentDriveId={attachment.driveDiscoveryId}
+				attachmentName={attachment.name}
+				attachmentVariant={variant}
+				projectId={projectId}
+			/>
+		</ImageButtonLink>
+	)
+}
 
-						<AudioDurationText
-							projectId={projectId}
-							attachmentDriveId={attachment.driveDiscoveryId}
-							attachmentName={attachment.name}
-						/>
-					</Stack>
-				</IconButtonLink>
-			)
-		}
-		default: {
-			// TODO: Needs more design direction
-			return (
-				<IconButton
-					sx={BASE_ATTACHMENT_CONTAINER_STYLE}
-					// TODO: Open dialog with attachment info?
-					onClick={() => {
-						alert(attachment.name)
-					}}
-				>
-					<Stack
-						direction="column"
-						gap={2}
-						justifyContent="center"
-						alignItems="center"
-						overflow={'auto'}
-					>
-						<Icon name="material-attachment" htmlColor={DARK_GREY} />
-					</Stack>
-				</IconButton>
-			)
-		}
-	}
+export function ObservationAudioAttachmentPreview({
+	attachment,
+	projectId,
+	variant,
+}: {
+	attachment: AudioAttachment
+	projectId: string
+	variant: AudioAttachmentVariant
+}) {
+	return (
+		<IconButtonLink
+			sx={BASE_ATTACHMENT_CONTAINER_STYLE}
+			to="/app/projects/$projectId/observations/$observationDocId/attachments/$driveId/$type/$variant/$name"
+			params={(prev) => ({
+				...prev,
+				driveId: attachment.driveDiscoveryId,
+				type: 'audio' as const,
+				variant,
+				name: attachment.name,
+			})}
+		>
+			<Stack
+				direction="column"
+				gap={2}
+				justifyContent="center"
+				alignItems="center"
+			>
+				<Icon name="material-volume-up" htmlColor={DARK_GREY} />
+
+				<AudioDurationText
+					projectId={projectId}
+					attachmentDriveId={attachment.driveDiscoveryId}
+					attachmentName={attachment.name}
+					attachmentVariant={variant}
+				/>
+			</Stack>
+		</IconButtonLink>
+	)
+}
+
+// TODO: Needs more design direction
+export function ObservationUnsupportedAttachmentPreview({
+	attachmentName,
+}: {
+	attachmentName: string
+}) {
+	return (
+		<IconButton
+			sx={BASE_ATTACHMENT_CONTAINER_STYLE}
+			// TODO: Open dialog with attachment info?
+			onClick={() => {
+				alert(attachmentName)
+			}}
+		>
+			<Stack
+				direction="column"
+				gap={2}
+				justifyContent="center"
+				alignItems="center"
+				overflow={'auto'}
+			>
+				<Icon name="material-attachment" htmlColor={DARK_GREY} />
+			</Stack>
+		</IconButton>
+	)
 }
 
 export function ObservationAttachmentError() {
@@ -133,10 +152,12 @@ export function ObservationAttachmentPending() {
 function AudioDurationText({
 	attachmentDriveId,
 	attachmentName,
+	attachmentVariant,
 	projectId,
 }: {
 	attachmentDriveId: string
 	attachmentName: string
+	attachmentVariant: AudioAttachmentVariant
 	projectId: string
 }) {
 	const { data: url } = useAttachmentUrl({
@@ -144,7 +165,7 @@ function AudioDurationText({
 		blobId: {
 			driveId: attachmentDriveId,
 			name: attachmentName,
-			variant: 'original',
+			variant: attachmentVariant,
 			type: 'audio',
 		},
 	})

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/attachments/$driveId.$type.$variant.$name.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/attachments/$driveId.$type.$variant.$name.tsx
@@ -16,6 +16,7 @@ import Dialog from '@mui/material/Dialog'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
+import { captureMessage } from '@sentry/react'
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, redirect, useRouter } from '@tanstack/react-router'
 import { defineMessages, useIntl } from 'react-intl'
@@ -333,6 +334,13 @@ function AttachmentPanel({
 					{blobId.type === 'photo' ? (
 						<ErrorBoundary
 							getResetKey={() => errorResetKey}
+							onError={() => {
+								captureMessage(`Failed to load ${blobId.variant} image`, {
+									level: 'info',
+									extra: blobId,
+								})
+							}}
+							// TODO: Consider redirecting to other variants recursively
 							fallback={() => (
 								<Box
 									display="grid"
@@ -375,6 +383,7 @@ function AttachmentPanel({
 									<PhotoAttachmentImage
 										attachmentDriveId={blobId.driveId}
 										attachmentName={blobId.name}
+										attachmentVariant={blobId.variant}
 										projectId={projectId}
 									/>
 								</Box>

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/index.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useState } from 'react'
+import { Suspense, useEffect, useState, type JSX } from 'react'
 import {
 	useDeleteDocument,
 	useManyDocs,
@@ -15,6 +15,7 @@ import Divider from '@mui/material/Divider'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
+import { captureException, captureMessage } from '@sentry/react'
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { defineMessages, useIntl } from 'react-intl'
@@ -43,6 +44,8 @@ import {
 	COORDINATOR_ROLE_ID,
 	CREATOR_ROLE_ID,
 	getMatchingCategoryForDocument,
+	isAudioAttachment,
+	isPhotoAttachment,
 	type ObservationTagValue,
 } from '../../../../../../lib/comapeo'
 import { formatCoords } from '../../../../../../lib/coordinate-format'
@@ -58,7 +61,9 @@ import { EditableNotesSection, ReadOnlyNotesSection } from './-notes-section'
 import {
 	ObservationAttachmentError,
 	ObservationAttachmentPending,
-	ObservationAttachmentPreview,
+	ObservationAudioAttachmentPreview,
+	ObservationPhotoAttachmentPreview,
+	ObservationUnsupportedAttachmentPreview,
 } from './-observation-attachment'
 import { getDisplayedTagValue, type EditableField } from './-shared'
 
@@ -596,17 +601,93 @@ function ObservationDetailsPanel({
 								{observation.attachments.map((attachment) => {
 									const key = `${attachment.driveDiscoveryId}/${attachment.type}/${attachment.name}/${attachment.hash}`
 
+									let previewToRender: JSX.Element
+
+									if (isPhotoAttachment(attachment)) {
+										previewToRender = (
+											<ErrorBoundary
+												getResetKey={() => key + ':preview'}
+												onError={() => {
+													captureMessage('Failed to load preview image', {
+														level: 'info',
+														extra: {
+															driveId: attachment.driveDiscoveryId,
+															name: attachment.name,
+														},
+													})
+												}}
+												fallback={() => (
+													<ObservationPhotoAttachmentPreview
+														projectId={projectId}
+														attachment={attachment}
+														variant="thumbnail"
+													/>
+												)}
+											>
+												<ErrorBoundary
+													getResetKey={() => key + ':original'}
+													onError={() => {
+														captureMessage('Failed to load original image', {
+															level: 'info',
+															extra: {
+																driveId: attachment.driveDiscoveryId,
+																name: attachment.name,
+															},
+														})
+													}}
+													fallback={() => (
+														<ObservationPhotoAttachmentPreview
+															projectId={projectId}
+															attachment={attachment}
+															variant="preview"
+														/>
+													)}
+												>
+													<ObservationPhotoAttachmentPreview
+														projectId={projectId}
+														attachment={attachment}
+														variant="original"
+													/>
+												</ErrorBoundary>
+											</ErrorBoundary>
+										)
+									} else if (isAudioAttachment(attachment)) {
+										previewToRender = (
+											<ObservationAudioAttachmentPreview
+												projectId={projectId}
+												attachment={attachment}
+												variant="original"
+											/>
+										)
+									} else {
+										previewToRender = (
+											<ObservationUnsupportedAttachmentPreview
+												attachmentName={attachment.name}
+											/>
+										)
+									}
+
 									return (
 										<ErrorBoundary
 											key={key}
 											getResetKey={() => key}
+											onError={(err) => {
+												captureException(
+													new Error('Failed to load attachment'),
+													{
+														originalException: err,
+														data: {
+															driveId: attachment.driveDiscoveryId,
+															name: attachment.name,
+															type: attachment.type,
+														},
+													},
+												)
+											}}
 											fallback={() => <ObservationAttachmentError />}
 										>
 											<Suspense fallback={<ObservationAttachmentPending />}>
-												<ObservationAttachmentPreview
-													attachment={attachment}
-													projectId={projectId}
-												/>
+												{previewToRender}
 											</Suspense>
 										</ErrorBoundary>
 									)


### PR DESCRIPTION
Fixes #447 

The following places have been updated as follows:

1. Observations list: used to only render previews. Now we fallback to thumbnails if previews cannot be loaded.
2. Observation details: used to only render originals. Now we fallback to previews if originals cannot be loaded, and then thumbnails if previews cannot be loaded.
3. Observation attachment: used to only render originals. Now we render the variant that matches the `variant` param in the URL. Note that we DO NOT try to render other variants as fallbacks. We can consider doing that or redirecting to the relevant URLs if desired, but in most cases this won't be necessary since navigation links to this page are only available based on the presence of the relevant variant.

For all of these, I've also improved the error handling so that there are clearer logs in Sentry. Before, we'd get reports about the image load error event from `SuspenseImage`, which were not very informative e.g. title would be something like `AsyncContextStack.withScope` and message like `Event (type=error) captured as exception`. Now we provide a more semantic log e.g. `Failed to load original image` along with a payload about the attachment/blob that can be found in the `Additional Data` section on Sentry.