### PR TITLE
chore: refactor effects handling in project data map

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId/-displayed-data/map.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/-displayed-data/map.tsx
@@ -49,6 +49,7 @@ import {
 } from 'react-map-gl/maplibre'
 import * as v from 'valibot'
 
+import type { HighlightedDocument } from '../-shared.ts'
 import { BLACK, BLUE_GREY, ORANGE, WHITE } from '../../../../../colors'
 import {
 	CategoryIconContainer,
@@ -63,7 +64,6 @@ import {
 import { useMapsRefreshToken } from '../../../../../hooks/maps'
 import { getMatchingCategoryForDocument } from '../../../../../lib/comapeo'
 import { getLocaleStateQueryOptions } from '../../../../../lib/queries/app-settings'
-import type { HighlightedDocument } from '../route.tsx'
 
 // TODO: Move to lib/colors
 const SHADOW_COLOR = '#686868'

--- a/src/renderer/src/routes/app/projects/$projectId/-shared.ts
+++ b/src/renderer/src/routes/app/projects/$projectId/-shared.ts
@@ -1,0 +1,9 @@
+import * as v from 'valibot'
+
+export const HighlightedDocumentSchema = v.object({
+	type: v.union([v.literal('observation'), v.literal('track')]),
+	docId: v.string(),
+	from: v.union([v.literal('map'), v.literal('list')]),
+})
+
+export type HighlightedDocument = v.InferInput<typeof HighlightedDocumentSchema>

--- a/src/renderer/src/routes/app/projects/$projectId/route.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/route.tsx
@@ -9,20 +9,11 @@ import { BLACK } from '../../../../colors'
 import { GenericRoutePendingComponent } from '../../../../components/generic-route-pending-component'
 import { COMAPEO_CORE_REACT_ROOT_QUERY_KEY } from '../../../../lib/comapeo'
 import { DisplayedDataMap } from './-displayed-data/map'
+import { HighlightedDocumentSchema } from './-shared.ts'
 
 const SearchParamsSchema = v.object({
-	highlightedDocument: v.optional(
-		v.object({
-			type: v.union([v.literal('observation'), v.literal('track')]),
-			docId: v.string(),
-			from: v.union([v.literal('map'), v.literal('list')]),
-		}),
-	),
+	highlightedDocument: v.optional(HighlightedDocumentSchema),
 })
-
-export type HighlightedDocument = NonNullable<
-	v.InferOutput<typeof SearchParamsSchema>['highlightedDocument']
->
 
 export const Route = createFileRoute('/app/projects/$projectId')({
 	validateSearch: SearchParamsSchema,


### PR DESCRIPTION
Follow-up to #422 . Makes use of [`useEffectEvent`](https://react.dev/reference/react/useEffectEvent) where (supposedly) appropriate.