### PR TITLE
fix: fix error with zoom-to-data map control when no data available

### DIFF
--- a/src/renderer/src/components/map-controls.tsx
+++ b/src/renderer/src/components/map-controls.tsx
@@ -222,11 +222,21 @@ class ZoomToDataControl implements IControl {
 					const maxLon = Math.max(...bboxes.map((bbox) => bbox[2]))
 					const maxLat = Math.max(...bboxes.map((bbox) => bbox[3]))
 
-					map.fitBounds(
-						[minLon, minLat, maxLon, maxLat],
-						this.#options.fitBoundsOptions,
-						{ originalEvent: event },
-					)
+					const calculatedBbox: [number, number, number, number] = [
+						minLon,
+						minLat,
+						maxLon,
+						maxLat,
+					]
+
+					// NOTE: Happens when no data exists
+					if (calculatedBbox.every((v) => v === Infinity || v === -Infinity)) {
+						return
+					}
+
+					map.fitBounds(calculatedBbox, this.#options.fitBoundsOptions, {
+						originalEvent: event,
+					})
 				} catch (err) {
 					captureException(err)
 				}

--- a/src/renderer/src/routes/app/projects/$projectId/-map-panel.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/-map-panel.tsx
@@ -723,11 +723,13 @@ export function MapPanel() {
 
 				<NavigationControl showCompass={false} />
 
-				<ZoomToDataMapControl
-					buttonTitle={t(m.zoomToData)}
-					fitBoundsOptions={BASE_FIT_BOUNDS_OPTIONS}
-					sourceIds={[OBSERVATIONS_SOURCE_ID, TRACKS_SOURCE_ID]}
-				/>
+				{observations.length + tracks.length > 0 ? (
+					<ZoomToDataMapControl
+						buttonTitle={t(m.zoomToData)}
+						fitBoundsOptions={BASE_FIT_BOUNDS_OPTIONS}
+						sourceIds={[OBSERVATIONS_SOURCE_ID, TRACKS_SOURCE_ID]}
+					/>
+				) : null}
 
 				{documentToHighlight ? (
 					<ZoomToSelectedDocumentMapControl


### PR DESCRIPTION
When pressing the control when no data is available, we'd get an invalid bounding box that we tried to zoom to. The map control code handles this case and does nothing, but we also no longer show the control on the map if there's no data.