### PR TITLE
chore: update Sentry setup

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,6 @@
 ### Sentry
 # SENTRY_AUTH_TOKEN=<value> # Auth token for Sentry
+# SENTRY_DSN=<value> # Sentry DSN
 # SENTRY_ORG=<value> # Sentry organization
 # SENTRY_PROJECT=<value> # Sentry project name
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
         env:
           APP_TYPE: 'internal'
           COMAPEO_TEST: 'true'
+          SENTRY_DSN: ${{ vars.COMAPEO_SENTRY_DSN }}
           VITE_FEATURE_TEST_DATA_UI: 'true'
         run: node --run forge:package
 

--- a/.github/workflows/create-builds.yml
+++ b/.github/workflows/create-builds.yml
@@ -158,6 +158,7 @@ jobs:
           ONLINE_STYLE_URL: ${{ secrets.ONLINE_STYLE_URL }}
           VITE_FEATURE_TEST_DATA_UI: ${{ env.APP_TYPE == 'production' && 'false' || 'true' }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ vars.COMAPEO_SENTRY_DSN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -57,6 +57,10 @@ Make sure you have the desired Node version installed. For this project we encou
 
 If you need to use environment overrides, create a copy of the [`.env.template`](../.env.template) and call it `.env`.
 
+If you want logs and errors to be sent to Sentry as you run the app, you need to specify the following environment variables:
+
+- `SENTRY_DSN`: [Sentry Data Source Name (DSN)](https://docs.sentry.io/concepts/key-terms/dsn-explainer/)
+
 If you're planning to use a different online map style, you'll need to specify a couple of other environment variables:
 
 - `ONLINE_STYLE_URL`: Full URL that points to a compatible map's StyleJSON.

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -40,6 +40,7 @@ const {
 	COMAPEO_METRICS_ACCESS_TOKEN,
 	COMAPEO_TEST,
 	ONLINE_STYLE_URL,
+	SENTRY_DSN,
 	USER_DATA_PATH,
 	VITE_MAPBOX_ACCESS_TOKEN,
 } = v.parse(
@@ -82,6 +83,7 @@ const {
 			),
 		),
 		ONLINE_STYLE_URL: v.optional(v.pipe(v.string(), v.url())),
+		SENTRY_DSN: v.optional(v.pipe(v.string(), v.url())),
 		USER_DATA_PATH: v.optional(v.string()),
 		VITE_MAPBOX_ACCESS_TOKEN: v.optional(v.string()),
 	}),
@@ -90,6 +92,18 @@ const {
 
 if (typeof COMAPEO_TEST === 'boolean' && APP_TYPE !== 'internal') {
 	throw new Error('COMAPEO_TEST can only be used when APP_TYPE is "internal"')
+}
+
+if (!SENTRY_DSN) {
+	if (APP_TYPE === 'release-candidate' || APP_TYPE === 'production') {
+		throw new Error('SENTRY_DSN must be specified for RC and production builds')
+	}
+
+	if (APP_TYPE === 'internal') {
+		console.warn(
+			'SENTRY_DSN not specified for internal build. App will not report to Sentry.',
+		)
+	}
 }
 
 const RENDERER_VITE_CONFIG_PATH = fileURLToPath(
@@ -172,6 +186,7 @@ class CoMapeoDesktopForgePlugin extends PluginBase<CoMapeoDesktopForgePluginConf
 				diagnosticsUrl: COMAPEO_DIAGNOSTICS_METRICS_URL,
 			},
 			onlineStyleUrl: onlineStyleUrl?.toString(),
+			sentryDsn: SENTRY_DSN,
 			userDataPath: USER_DATA_PATH,
 			win32AppUserModelId:
 				process.platform === 'win32'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -104,7 +104,7 @@ if (appConfig.appType === 'release-candidate') {
 // NOTE: Has to be set up after user data directory is updated
 // https://docs.sentry.io/platforms/javascript/guides/electron/#app-userdata-directory
 Sentry.init({
-	dsn: 'https://f7336c12cc39fb0367886e31036a6cd7@o4507148235702272.ingest.us.sentry.io/4509803831820288',
+	dsn: appConfig.sentryDsn,
 	// NOTE: Only works on app startup. Any changes to `diagnosticsEnabled` while the app is running will not
 	// take effect here until the app is restarted.
 	enabled: persistedStoreState.diagnosticsEnabled,

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -112,7 +112,6 @@ const sentryConfig = window.runtime.getSentryConfig()
 
 initSentryElectron(
 	{
-		dsn: 'https://f7336c12cc39fb0367886e31036a6cd7@o4507148235702272.ingest.us.sentry.io/4509803831820288',
 		enabled: sentryConfig.enabled,
 		// TODO: Enable tracing based on user consent in production
 		tracesSampleRate: sentryConfig.environment === 'production' ? 0 : 1.0,
@@ -121,7 +120,6 @@ initSentryElectron(
 			sentryConfig.environment === 'production'
 				? undefined
 				: [tanstackRouterBrowserTracingIntegration(router)],
-		environment: sentryConfig.environment,
 		debug: sentryConfig.environment === 'development',
 		initialScope: { user: { id: sentryConfig.userId } },
 	},

--- a/src/shared/app.ts
+++ b/src/shared/app.ts
@@ -33,6 +33,8 @@ export const AppConfigSchema = v.object({
 	}),
 	/** Sets the online map style for @comapeo/core to use */
 	onlineStyleUrl: v.optional(v.pipe(v.string(), v.url())),
+	/** [Sentry DSN](https://docs.sentry.io/concepts/key-terms/dsn-explainer/) */
+	sentryDsn: v.optional(v.pipe(v.string(), v.url())),
 	/** Sets the user data directory for the application to use */
 	userDataPath: v.optional(v.string()),
 	/**


### PR DESCRIPTION
Makes the Sentry DSN used a configurable environment variable instead of something that's hardcoded into the source code. In theory, this makes the project easier to work with for external contributors and also allows more control over Sentry configuration for builds.

I've already added a repo variable called `COMAPEO_SENTRY_DSN` that uses the existing value.