### PR TITLE
chore: remove form and field components usage in createFormHook

### DIFF
--- a/src/renderer/src/hooks/forms.ts
+++ b/src/renderer/src/hooks/forms.ts
@@ -1,16 +1,10 @@
-import Button from '@mui/material/Button'
-import TextField from '@mui/material/TextField'
 import { createFormHook, createFormHookContexts } from '@tanstack/react-form'
 
 const { fieldContext, formContext } = createFormHookContexts()
 
 const { useAppForm } = createFormHook({
-	fieldComponents: {
-		TextField,
-	},
-	formComponents: {
-		SubmitButton: Button,
-	},
+	fieldComponents: {},
+	formComponents: {},
 	fieldContext,
 	formContext,
 })

--- a/src/renderer/src/routes/app/projects/$projectId/download.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/download.tsx
@@ -363,7 +363,7 @@ function DownloadForm({
 							}
 						>
 							{([canSubmit, isSubmitting]) => (
-								<form.SubmitButton
+								<Button
 									type="submit"
 									form={FORM_ID}
 									fullWidth
@@ -375,7 +375,7 @@ function DownloadForm({
 									sx={{ maxWidth: 400 }}
 								>
 									{t(m.download)}
-								</form.SubmitButton>
+								</Button>
 							)}
 						</form.Subscribe>
 					</Box>

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-field-editors.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-field-editors.tsx
@@ -6,6 +6,7 @@ import FormGroup from '@mui/material/FormGroup'
 import Radio from '@mui/material/Radio'
 import RadioGroup from '@mui/material/RadioGroup'
 import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
 import { defineMessages, useIntl } from 'react-intl'
 import * as v from 'valibot'
 
@@ -60,7 +61,7 @@ export function TextFieldEditor({
 		>
 			<form.AppField name="answer">
 				{(formField) => (
-					<formField.TextField
+					<TextField
 						fullWidth
 						multiline={field.appearance !== 'singleline'}
 						aria-label={field.label}
@@ -88,7 +89,7 @@ export function TextFieldEditor({
 				<form.Subscribe selector={(state) => state.isSubmitting}>
 					{(isSubmitting) => (
 						<>
-							<form.SubmitButton
+							<Button
 								type="submit"
 								fullWidth
 								sx={{ maxWidth: 400 }}
@@ -97,7 +98,7 @@ export function TextFieldEditor({
 								endIcon={<Icon name="material-check-circle-outline-rounded" />}
 							>
 								{t(m.saveButtonText)}
-							</form.SubmitButton>
+							</Button>
 
 							<Button
 								type="button"
@@ -165,7 +166,7 @@ export function NumberFieldEditor({
 		>
 			<form.AppField name="answer">
 				{(formField) => (
-					<formField.TextField
+					<TextField
 						fullWidth
 						aria-label={field.label}
 						autoFocus
@@ -198,7 +199,7 @@ export function NumberFieldEditor({
 				<form.Subscribe selector={(state) => state.isSubmitting}>
 					{(isSubmitting) => (
 						<>
-							<form.SubmitButton
+							<Button
 								type="submit"
 								fullWidth
 								sx={{ maxWidth: 400 }}
@@ -207,7 +208,7 @@ export function NumberFieldEditor({
 								endIcon={<Icon name="material-check-circle-outline-rounded" />}
 							>
 								{t(m.saveButtonText)}
-							</form.SubmitButton>
+							</Button>
 
 							<Button
 								type="button"
@@ -320,7 +321,7 @@ export function SingleSelectFieldEditor({
 				<form.Subscribe selector={(state) => state.isSubmitting}>
 					{(isSubmitting) => (
 						<>
-							<form.SubmitButton
+							<Button
 								type="submit"
 								fullWidth
 								sx={{ maxWidth: 400 }}
@@ -329,7 +330,7 @@ export function SingleSelectFieldEditor({
 								endIcon={<Icon name="material-check-circle-outline-rounded" />}
 							>
 								{t(m.saveButtonText)}
-							</form.SubmitButton>
+							</Button>
 
 							<Button
 								type="button"
@@ -425,7 +426,7 @@ export function MultiSelectFieldEditor({
 				<form.Subscribe selector={(state) => state.isSubmitting}>
 					{(isSubmitting) => (
 						<>
-							<form.SubmitButton
+							<Button
 								type="submit"
 								fullWidth
 								sx={{ maxWidth: 400 }}
@@ -434,7 +435,7 @@ export function MultiSelectFieldEditor({
 								endIcon={<Icon name="material-check-circle-outline-rounded" />}
 							>
 								{t(m.saveButtonText)}
-							</form.SubmitButton>
+							</Button>
 
 							<Button
 								type="button"

--- a/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-notes-section.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/observations/$observationDocId/-notes-section.tsx
@@ -2,6 +2,7 @@ import { useSingleDocByDocId, useUpdateDocument } from '@comapeo/core-react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { captureException } from '@sentry/react'
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query'
@@ -199,7 +200,7 @@ function NotesEditor({
 			<Stack direction="column" gap={4}>
 				<form.AppField name="notes">
 					{(field) => (
-						<field.TextField
+						<TextField
 							fullWidth
 							multiline
 							aria-label={t(m.accessibleNotesInputLabel)}
@@ -227,7 +228,7 @@ function NotesEditor({
 					<form.Subscribe selector={(state) => state.isSubmitting}>
 						{(isSubmitting) => (
 							<>
-								<form.SubmitButton
+								<Button
 									type="submit"
 									fullWidth
 									sx={{ maxWidth: 400 }}
@@ -238,7 +239,7 @@ function NotesEditor({
 									}
 								>
 									{t(m.saveButtonText)}
-								</form.SubmitButton>
+								</Button>
 
 								<Button
 									type="button"

--- a/src/renderer/src/routes/app/projects/$projectId_/settings/info.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/settings/info.tsx
@@ -12,6 +12,7 @@ import FormGroup from '@mui/material/FormGroup'
 import FormLabel from '@mui/material/FormLabel'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { defineMessages, useIntl } from 'react-intl'
@@ -201,7 +202,7 @@ function RouteComponent() {
 								<Box paddingInline={6}>
 									<form.AppField name="projectName">
 										{(field) => (
-											<field.TextField
+											<TextField
 												required
 												fullWidth
 												label={t(m.projectNameInputLabel)}
@@ -253,7 +254,7 @@ function RouteComponent() {
 								<Box paddingInline={6}>
 									<form.AppField name="projectDescription">
 										{(field) => (
-											<field.TextField
+											<TextField
 												fullWidth
 												multiline
 												rows={3}
@@ -454,7 +455,7 @@ function RouteComponent() {
 										{t(m.cancel)}
 									</Button>
 
-									<form.SubmitButton
+									<Button
 										type="submit"
 										form={FORM_ID}
 										fullWidth
@@ -465,7 +466,7 @@ function RouteComponent() {
 										sx={{ maxWidth: 400 }}
 									>
 										{t(m.save)}
-									</form.SubmitButton>
+									</Button>
 								</>
 							)}
 						</form.Subscribe>

--- a/src/renderer/src/routes/app/settings/device-name.tsx
+++ b/src/renderer/src/routes/app/settings/device-name.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { defineMessages, useIntl } from 'react-intl'
@@ -138,7 +139,7 @@ function RouteComponent() {
 						>
 							<form.AppField name="deviceName">
 								{(field) => (
-									<field.TextField
+									<TextField
 										required
 										fullWidth
 										label={t(m.inputLabel)}
@@ -226,7 +227,7 @@ function RouteComponent() {
 										{t(m.cancel)}
 									</Button>
 
-									<form.SubmitButton
+									<Button
 										type="submit"
 										form={FORM_ID}
 										fullWidth
@@ -237,7 +238,7 @@ function RouteComponent() {
 										sx={{ maxWidth: 400 }}
 									>
 										{t(m.save)}
-									</form.SubmitButton>
+									</Button>
 								</>
 							)}
 						</form.Subscribe>

--- a/src/renderer/src/routes/app/settings_/test-data.tsx
+++ b/src/renderer/src/routes/app/settings_/test-data.tsx
@@ -19,6 +19,7 @@ import MenuItem from '@mui/material/MenuItem'
 import Select from '@mui/material/Select'
 import Snackbar from '@mui/material/Snackbar'
 import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { useStore } from '@tanstack/react-form'
 import { useMutation } from '@tanstack/react-query'
@@ -353,7 +354,7 @@ function RouteComponent() {
 
 										<form.AppField name="observationCount">
 											{(field) => (
-												<field.TextField
+												<TextField
 													required
 													fullWidth
 													label={t(m.observationCountLabel)}
@@ -405,7 +406,7 @@ function RouteComponent() {
 												>
 													<form.AppField name="longitude">
 														{(field) => (
-															<field.TextField
+															<TextField
 																fullWidth
 																aria-disabled
 																disabled
@@ -424,7 +425,7 @@ function RouteComponent() {
 
 													<form.AppField name="latitude">
 														{(field) => (
-															<field.TextField
+															<TextField
 																fullWidth
 																aria-disabled
 																disabled
@@ -445,7 +446,7 @@ function RouteComponent() {
 
 											<form.AppField name="boundedDistance">
 												{(field) => (
-													<field.TextField
+													<TextField
 														required
 														fullWidth
 														label={t(m.boundedDistanceLabel)}
@@ -526,7 +527,7 @@ function RouteComponent() {
 												{t(m.cancel)}
 											</Button>
 
-											<form.SubmitButton
+											<Button
 												type="submit"
 												form={FORM_ID}
 												fullWidth
@@ -537,7 +538,7 @@ function RouteComponent() {
 												sx={{ maxWidth: 400 }}
 											>
 												{t(m.create)}
-											</form.SubmitButton>
+											</Button>
 										</>
 									)}
 								</form.Subscribe>

--- a/src/renderer/src/routes/onboarding/device-name.tsx
+++ b/src/renderer/src/routes/onboarding/device-name.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react'
 import { useOwnDeviceInfo, useSetOwnDeviceInfo } from '@comapeo/core-react'
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
 import Container from '@mui/material/Container'
 import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { captureException } from '@sentry/react'
 import { useStore } from '@tanstack/react-form'
@@ -136,7 +138,7 @@ function RouteComponent() {
 					>
 						<form.AppField name="deviceName">
 							{(field) => (
-								<field.TextField
+								<TextField
 									id={field.name}
 									required
 									fullWidth
@@ -193,7 +195,7 @@ function RouteComponent() {
 				<Box display="flex" justifyContent="center">
 					<form.Subscribe selector={(state) => state.canSubmit}>
 						{(canSubmit) => (
-							<form.SubmitButton
+							<Button
 								fullWidth
 								form="device-name-form"
 								variant="contained"
@@ -202,7 +204,7 @@ function RouteComponent() {
 								sx={{ maxWidth: 400 }}
 							>
 								{t(m.addName)}
-							</form.SubmitButton>
+							</Button>
 						)}
 					</form.Subscribe>
 				</Box>

--- a/src/renderer/src/routes/onboarding/project/create/index.tsx
+++ b/src/renderer/src/routes/onboarding/project/create/index.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react'
 import { useCreateProject } from '@comapeo/core-react'
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
 import Container from '@mui/material/Container'
 import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { captureException } from '@sentry/react'
 import { useMutation } from '@tanstack/react-query'
@@ -123,7 +125,7 @@ function RouteComponent() {
 				>
 					<form.AppField name="projectName">
 						{(field) => (
-							<field.TextField
+							<TextField
 								id={field.name}
 								required
 								fullWidth
@@ -182,7 +184,7 @@ function RouteComponent() {
 					selector={(state) => [state.canSubmit, state.isSubmitting]}
 				>
 					{([canSubmit, isSubmitting]) => (
-						<form.SubmitButton
+						<Button
 							fullWidth
 							form="device-name-form"
 							variant="contained"
@@ -195,7 +197,7 @@ function RouteComponent() {
 							startIcon={<Icon name="material-check-circle-outline-rounded" />}
 						>
 							{t(m.createButton)}
-						</form.SubmitButton>
+						</Button>
 					)}
 				</form.Subscribe>
 			</Box>


### PR DESCRIPTION
No longer uses the `fieldComponents` and `formComponents` option for setting up form-related components with tanstack form. These are useful if the components passed in are making use of the libraries form composition APIs, but we currently don't do that.