### PR TITLE
fix: handle parsing errors when reading from metrics files

### DIFF
--- a/src/main/metrics/app-diagnostics-metrics.ts
+++ b/src/main/metrics/app-diagnostics-metrics.ts
@@ -58,15 +58,18 @@ export function createAppDiagnosticsMetricsScheduler({
 		},
 		storage: {
 			get: async () => {
-				let content: unknown
-
+				let rawContent
 				try {
-					content = JSON.parse(
-						await readFile(storageFilePath, { encoding: 'utf-8' }),
-					)
+					rawContent = await readFile(storageFilePath, { encoding: 'utf-8' })
+				} catch {
+					return undefined
+				}
+
+				let parsedContent: unknown
+				try {
+					parsedContent = JSON.parse(rawContent)
 				} catch (err) {
 					captureException(err)
-
 					return undefined
 				}
 
@@ -80,7 +83,7 @@ export function createAppDiagnosticsMetricsScheduler({
 							]),
 						),
 					}),
-					content,
+					parsedContent,
 				)
 
 				if (!result.success) {

--- a/src/main/metrics/device-diagnostics-metrics.ts
+++ b/src/main/metrics/device-diagnostics-metrics.ts
@@ -69,19 +69,22 @@ export class DeviceDiagnosticsMetrics {
 	}
 
 	async #readStorage() {
-		let content: unknown
-
+		let rawContent
 		try {
-			content = JSON.parse(
-				await readFile(this.#storageFilePath, { encoding: 'utf-8' }),
-			)
-		} catch (err) {
-			captureException(err)
-
+			rawContent = await readFile(this.#storageFilePath, { encoding: 'utf-8' })
+		} catch {
 			return undefined
 		}
 
-		const result = v.safeParse(DeviceDiagnosticsStorageSchema, content)
+		let parsedContent: unknown
+		try {
+			parsedContent = JSON.parse(rawContent)
+		} catch (err) {
+			captureException(err)
+			return undefined
+		}
+
+		const result = v.safeParse(DeviceDiagnosticsStorageSchema, parsedContent)
 
 		if (!result.success) {
 			return undefined


### PR DESCRIPTION
Seeing [this unhandled error on Sentry](https://awana-digital.sentry.io/issues/7000993553/) prompted this. Not sure why the input is bad (potentially empty file?) - will need to keep an eye on it.