### PR TITLE
chore: update default bounding box used for observations map

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId/-map-panel.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/-map-panel.tsx
@@ -113,7 +113,7 @@ const TRACKS_HOVER_SHADOW_LAYER_PAINT_PROPERTY: LineLayerSpecification['paint'] 
 const INTERACTIVE_LAYER_IDS = [OBSERVATIONS_LAYER_ID, TRACKS_LAYER_ID]
 
 const DEFAULT_BOUNDING_BOX: [number, number, number, number] = [
-	-180, -90, 180, 90,
+	-180, -85.0511, 180, 85.0511,
 ]
 
 const BASE_FIT_BOUNDS_OPTIONS: FitBoundsOptions = {


### PR DESCRIPTION
Updates the bounding box used for the map where there's no data to show. Something I learned via https://github.com/digidem/comapeo-map-server/pull/2#discussion_r2623837565