### PR TITLE
chore: minor adjustments to the join project onboarding page

### DIFF
--- a/src/renderer/src/routes/onboarding/project/join/index.tsx
+++ b/src/renderer/src/routes/onboarding/project/join/index.tsx
@@ -11,7 +11,6 @@ import Container from '@mui/material/Container'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import Zoom from '@mui/material/Zoom'
-import { alpha } from '@mui/material/styles'
 import { captureException } from '@sentry/react'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
@@ -19,13 +18,7 @@ import { defineMessages, useIntl } from 'react-intl'
 import { TransitionGroup } from 'react-transition-group'
 
 import { ONBOARDING_BASE_MUTATION_KEY } from '../-shared'
-import {
-	BLACK,
-	DARKER_ORANGE,
-	DARK_GREY,
-	LIGHT_GREY,
-	WHITE,
-} from '../../../../colors'
+import { BLUE_GREY, DARKER_ORANGE, DARK_GREY, WHITE } from '../../../../colors'
 import {
 	ErrorDialog,
 	type Props as ErrorDialogProps,
@@ -65,8 +58,6 @@ function RouteComponent() {
 		</Container>
 	)
 }
-
-const BOX_SHADOW = `0px 1px 5px 0px ${alpha(BLACK, 0.25)}`
 
 function PendingInvite() {
 	const router = useRouter()
@@ -132,9 +123,9 @@ function PendingInvite() {
 							gap={6}
 							borderRadius={2}
 							padding={6}
-							boxShadow={BOX_SHADOW}
+							boxShadow={(theme) => theme.shadows[5]}
 							bgcolor={pendingInvite.projectColor || WHITE}
-							border={`2px solid ${LIGHT_GREY}`}
+							border={`1px solid ${BLUE_GREY}`}
 						>
 							<Typography variant="h1" fontWeight={500}>
 								{pendingInvite.projectName}


### PR DESCRIPTION
- fixes a console error related to unusable react transition group props
- displays a loading state for the decline invite button when pressed. usually imperceptible because of how fast it happens but just in case.
- updates the pending invite card to visually align with other similar card designs

---

<img width="600" alt="image" src="https://github.com/user-attachments/assets/66babb90-5f86-41c4-a971-70036efae771" />

