### PR TITLE
fix: account for another case of redacted ssid on macOS

### DIFF
--- a/src/renderer/src/routes/app/projects/-shared/network-connection-info.tsx
+++ b/src/renderer/src/routes/app/projects/-shared/network-connection-info.tsx
@@ -53,7 +53,8 @@ export function NetworkConnectionInfo({
 					<Typography fontWeight={500}>
 						{wifiConnection &&
 						// NOTE: Issue with systeminformation module on macOS >=15.6 (https://github.com/digidem/comapeo-desktop/issues/378)
-						wifiConnection.ssid !== '&lt;redacted&gt;'
+						wifiConnection.ssid !== '&lt;redacted&gt;' &&
+						wifiConnection.ssid !== '<redacted>'
 							? `${wifiConnection.ssid}${
 									netInfo.effectiveType
 										? // TODO: Should the effectiveType be translatable?


### PR DESCRIPTION
Not sure if this was a regression caused by `systeminformation` or due to me updating my OS yesterday. Guessing the latter.