### PR TITLE
fix: fix error screen after device accepts invite sent by us

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId_/invite/devices/$deviceId/route.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/invite/devices/$deviceId/route.tsx
@@ -22,9 +22,9 @@ export const Route = createFileRoute(
 			})
 		}
 
-		// NOTE: This is intentionally a plain call instead of that's wrapped in
+		// NOTE: This is intentionally a plain call instead of something that's wrapped in
 		// `queryClient.ensureQueryData()`, `queryClient.fetchQuery()`, etc.
-		// This prevents an issue with showing thesuccess screen when another device accepts an invite sent by us.
+		// This prevents an issue with showing the success state when another device accepts an invite sent by us.
 		const member = await projectApi.$member.getById(deviceId).catch(() => {
 			return null
 		})


### PR DESCRIPTION
Fixes a regression introduced by #485 . Repro steps:

1. Invite mobile device from desktop
2. On mobile device, accept invite.
3. On desktop, observe the following:

    <img width="600" alt="image" src="https://github.com/user-attachments/assets/df79646c-f8ff-4992-b092-a33ee8b2bbbc" />
    
Still a little miffed at the behavior, as it seems to be some sort of race condition or a misuse of router/query. Haven't really wrapped my head around where the actual issue lies, but guessing it's on our end.
