### PR TITLE
chore: add restart button for generic route error component

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -23,6 +23,10 @@
     "description": "Text for button to reload page.",
     "message": "Reload"
   },
+  "components.generic-route-error-component.restart": {
+    "description": "Text for button to restart app.",
+    "message": "Restart"
+  },
   "components.generic-route-error-component.somethinWentWrong": {
     "description": "Title text of page error",
     "message": "Something went wrong"

--- a/src/renderer/src/components/generic-route-error-component.tsx
+++ b/src/renderer/src/components/generic-route-error-component.tsx
@@ -84,6 +84,7 @@ export function GenericRouteErrorComponent({ error }: ErrorComponentProps) {
 				display="flex"
 				flexDirection="column"
 				alignItems="center"
+				gap={4}
 			>
 				<Button
 					fullWidth
@@ -96,6 +97,20 @@ export function GenericRouteErrorComponent({ error }: ErrorComponentProps) {
 					sx={{ maxWidth: 400 }}
 				>
 					{t(m.reload)}
+				</Button>
+
+				<Button
+					fullWidth
+					variant="outlined"
+					onClick={() => {
+						router.navigate({
+							href: buildDocumentReloadURL(router, '/'),
+							reloadDocument: true,
+						})
+					}}
+					sx={{ maxWidth: 400 }}
+				>
+					{t(m.restart)}
 				</Button>
 			</Box>
 		</Stack>
@@ -122,5 +137,10 @@ const m = defineMessages({
 		id: 'components.generic-route-error-component.reload',
 		defaultMessage: 'Reload',
 		description: 'Text for button to reload page.',
+	},
+	restart: {
+		id: 'components.generic-route-error-component.restart',
+		defaultMessage: 'Restart',
+		description: 'Text for button to restart app.',
 	},
 })


### PR DESCRIPTION
When some generic route error occurs, we typically display a panel containing information about the error and a button that reloads the page. However, there are cases where you can get stuck on the page due to UI elements being intentionally disabled.

Now we provide a "restart" button which doesn't restart the application entirely, but just loads the "index" page as opposed to the current page, which is usually sufficient. Might be worth using different wording eventually, especially if we introduce something that actually restarts the application.

---

<img width="600" alt="image" src="https://github.com/user-attachments/assets/4665ebb9-e869-4586-bdd5-d1f5c9e42072" />
