### PR TITLE
fix: break and wrap archive server url on deviceId page

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId_/team/$deviceId.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId_/team/$deviceId.tsx
@@ -251,6 +251,7 @@ function CollaboratorInfoContent({
 				variant="h3"
 				fontWeight={500}
 				textAlign="center"
+				sx={{ overflowWrap: 'anywhere' }}
 			>
 				{member.selfHostedServerDetails.baseUrl}
 			</Typography>


### PR DESCRIPTION
Just a minor fix for something that was bugging me :)

Using the same pattern as on line 333 for the device ID.

Before:

![WhatsApp Image 2026-01-30 at 10 01 42](https://github.com/user-attachments/assets/ba9f176b-97c9-4315-9664-8520eda99d90)

After:

![WhatsApp Image 2026-01-30 at 10 06 17](https://github.com/user-attachments/assets/2dbe5661-f219-4f47-a733-3827d5c4bb6c)
