### PR TITLE
fix: adjust exchange page based on status of project members

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -415,9 +415,17 @@
     "description": "Text displayed when waiting for Wi-Fi information.",
     "message": "Getting Wi-Fi information…"
   },
+  "routes.app.projects.$projectId_.exchange.index.inviteDevices": {
+    "description": "Text for link to invite devices page.",
+    "message": "Invite Devices"
+  },
   "routes.app.projects.$projectId_.exchange.index.lookingForDevices": {
     "description": "Text displayed when no other devices have been found.",
     "message": "Looking for devices…"
+  },
+  "routes.app.projects.$projectId_.exchange.index.noOtherDevicesOnProject": {
+    "description": "Text indicating no other active devices are on the project.",
+    "message": "No other devices are on this project."
   },
   "routes.app.projects.$projectId_.exchange.index.remoteArchiveConnected": {
     "description": "Text indicating that some remote archive is connected.",

--- a/tests-e2e/specs/app/exchange.spec.ts
+++ b/tests-e2e/specs/app/exchange.spec.ts
@@ -56,65 +56,14 @@ test('solo ', async ({ appInfo, projectParams, userParams }) => {
 			await expect(networkConnectionInfo).not.toHaveText('&lt;redacted&gt;')
 
 			await expect(
-				main.getByRole('heading', {
-					name: 'Looking for devices…',
+				main.getByText('No other devices are on this project.', {
 					exact: true,
 				}),
 			).toBeVisible()
-
-			await expect(main.getByRole('progressbar')).not.toBeVisible()
-		}
-
-		//// Start exchange
-		{
-			const startButton = main.getByRole('button', {
-				name: 'Start',
-				exact: true,
-			})
-			await expect(startButton).toBeVisible()
-			await startButton.click()
-
-			const disabledNavLinks = page
-				.getByRole('navigation')
-				.getByRole('link', { disabled: true })
-
-			await expect(disabledNavLinks.first()).toHaveAccessibleName(
-				'View project.',
-			)
-
-			await expect(disabledNavLinks).toHaveText([
-				'',
-				'Team',
-				'Tools',
-				'Settings',
-			])
 
 			await expect(
-				main.getByRole('heading', {
-					name: 'Waiting for Devices',
-					exact: true,
-				}),
+				main.getByRole('link', { name: 'Invite Devices', exact: true }),
 			).toBeVisible()
-
-			await expect(main.getByRole('progressbar')).toBeVisible()
-
-			await expect(main.getByText(/^\d%$/)).toBeVisible()
-		}
-
-		//// Stop exchange
-		{
-			const stopButton = main.getByRole('button', {
-				name: 'Stop',
-				exact: true,
-			})
-			await expect(stopButton).toBeVisible()
-			await stopButton.click()
-
-			const disabledNavLinks = page
-				.getByRole('navigation')
-				.getByRole('link', { disabled: true })
-
-			await expect(disabledNavLinks).toHaveCount(0)
 		}
 	} finally {
 		// 3. Cleanup


### PR DESCRIPTION
Fixes #508 

Changes the initial state of the exchange page when creating a new project on desktop. Instead of showing a button to initiate exchange, we show a prompt to invite someone to the project. Once someone has joined the project we show the typical states, even when everyone but yourself has left the project.

---

<img width="600" alt="image" src="https://github.com/user-attachments/assets/bd5192ed-99d5-40f3-9343-a16aa4824d95" />
