### PR TITLE
fix: fix vertical overflow issue on welcome page

### DIFF
--- a/src/renderer/src/routes/welcome.tsx
+++ b/src/renderer/src/routes/welcome.tsx
@@ -36,7 +36,6 @@ function RouteComponent() {
 			display="flex"
 			justifyContent="center"
 			alignItems="center"
-			padding={5}
 			sx={{
 				backgroundImage: `url("${topographicPrintURL}")`,
 				backgroundRepeat: 'no-repeat',
@@ -44,7 +43,7 @@ function RouteComponent() {
 				backgroundSize: 'contain',
 			}}
 		>
-			<Container maxWidth="lg">
+			<Container maxWidth="lg" sx={{ overflow: 'auto', padding: 5 }}>
 				<Stack display="flex" alignItems="center" gap={25}>
 					<Grid container spacing={10} justifyContent="center">
 						<Grid


### PR DESCRIPTION
When the window height and width are made small enough, the vertical overflow handling on this page is suboptimal.

---

- Before

    <img width="600" alt="image" src="https://github.com/user-attachments/assets/92ff3cab-94a8-409d-ae16-af9d8eed4680" />

- After

    <img width="600" alt="image" src="https://github.com/user-attachments/assets/b960a984-1573-4cdb-9d21-dd6503e0088d" />
