### PR TITLE
fix: fix fallback styling of additional projects layout buttons

### DIFF
--- a/src/renderer/src/routes/app/index.tsx
+++ b/src/renderer/src/routes/app/index.tsx
@@ -251,7 +251,12 @@ function RouteComponent() {
 											replace
 											activeOptions={{ includeSearch: true }}
 											inactiveProps={{
-												sx: { color: BLUE_GREY },
+												sx: {
+													color: (theme) =>
+														additionalProjectsLayout === 'grid'
+															? theme.palette.text.primary
+															: BLUE_GREY,
+												},
 											}}
 											activeProps={{
 												sx: { color: (theme) => theme.palette.text.primary },
@@ -272,7 +277,12 @@ function RouteComponent() {
 											replace
 											activeOptions={{ includeSearch: true }}
 											inactiveProps={{
-												sx: { color: BLUE_GREY },
+												sx: {
+													color: (theme) =>
+														additionalProjectsLayout === 'list'
+															? theme.palette.text.primary
+															: BLUE_GREY,
+												},
 											}}
 											activeProps={{
 												sx: { color: (theme) => theme.palette.text.primary },


### PR DESCRIPTION
Follow-up to #526 where the neither layout button would be highlighted when navigating to the home page.