### PR TITLE
fix: adjust exchange autostop behavior

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/exchange/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/exchange/index.tsx
@@ -82,8 +82,19 @@ export const Route = createFileRoute(
 			}),
 		])
 	},
+	onEnter: async ({ context }) => {
+		try {
+			await context.projectApi.$sync.setAutostopDataSyncTimeout(null)
+		} catch (err) {
+			captureException(err)
+		}
+	},
 	onLeave: async ({ context }) => {
-		await context.projectApi.$sync.stop()
+		try {
+			await context.projectApi.$sync.setAutostopDataSyncTimeout(30_000)
+		} catch (err) {
+			captureException(err)
+		}
 	},
 	component: RouteComponent,
 })


### PR DESCRIPTION
I was working with an outdated model of how autostopping exchange works on mobile, thinking that we completely stop exchange when leaving the page. Instead, we make use of the the autostop timeout API provided by core, which is smarter about when to stop exchange in the background.