### PR TITLE
fix: fix horizontal overflow when viewing observation attachment

### DIFF
--- a/src/renderer/src/routes/app/-components/two-panel-layout.tsx
+++ b/src/renderer/src/routes/app/-components/two-panel-layout.tsx
@@ -14,7 +14,7 @@ export function TwoPanelLayout({
 	end: ReactNode
 }) {
 	return (
-		<Box sx={{ display: 'flex', flex: 1 }}>
+		<Box sx={{ display: 'flex', flex: 1, overflow: 'auto' }}>
 			<Box
 				sx={{
 					display: 'flex',

--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/observations/$observationDocId/attachments/$driveId.$type.$variant.$name.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/observations/$observationDocId/attachments/$driveId.$type.$variant.$name.tsx
@@ -381,6 +381,7 @@ function AttachmentPanel({
 										attachmentName={blobId.name}
 										attachmentVariant={blobId.variant}
 										projectId={projectId}
+										style={{ width: '100%' }}
 									/>
 								</Box>
 							</Suspense>


### PR DESCRIPTION
Fixes #575 

---

<img width="600" alt="image" src="https://github.com/user-attachments/assets/21581db5-5390-4a6e-a000-65600abcef17" />
