### PR TITLE
fix: improve discovery error handling

### DIFF
--- a/patches/@homebridge+ciao+1.3.8+001+handle-republish-errors.patch
+++ b/patches/@homebridge+ciao+1.3.8+001+handle-republish-errors.patch
@@ -1,0 +1,42 @@
+diff --git a/node_modules/@homebridge/ciao/lib/CiaoService.js b/node_modules/@homebridge/ciao/lib/CiaoService.js
+index a70f9b4..6140d2c 100644
+--- a/node_modules/@homebridge/ciao/lib/CiaoService.js
++++ b/node_modules/@homebridge/ciao/lib/CiaoService.js
+@@ -473,11 +473,11 @@ class CiaoService extends events_1.EventEmitter {
+             // thus, when sending the first request, the socket will be bound, and we don't need to wait here
+             this.emit("republish" /* InternalServiceEvent.REPUBLISH */, error => {
+                 if (error) {
+-                    console.log("FATAL Error occurred trying to re-announce service " + this.fqdn + "! We can't recover from this!");
+-                    console.log(error.stack);
+-                    process.exit(1); // we have a service which should be announced, though we failed to re-announce.
+-                    // if this should ever happen in reality, whe might want to introduce a more sophisticated recovery
+-                    // for situations where it makes sense
++                    console.error("Error occurred trying to re-announce service " + this.fqdn + ". Service is now unannounced and may need to be re-advertised.");
++                    console.error(error.stack);
++                    if (this.listeners("announce-error").length > 0) {
++                        this.emit("announce-error", error);
++                    }
+                 }
+             });
+         }
+diff --git a/node_modules/@homebridge/ciao/lib/Responder.js b/node_modules/@homebridge/ciao/lib/Responder.js
+index d690074..d7560c1 100644
+--- a/node_modules/@homebridge/ciao/lib/Responder.js
++++ b/node_modules/@homebridge/ciao/lib/Responder.js
+@@ -641,11 +641,11 @@ class Responder {
+                 // noinspection JSIgnoredPromiseFromCall
+                 this.republishService(service, error => {
+                     if (error) {
+-                        console.log(`FATAL Error occurred trying to resolve conflict for service ${service.getFQDN()}! We can't recover from this!`);
+-                        console.log(error.stack);
+-                        process.exit(1); // we have a service which should be announced, though we failed to reannounce.
+-                        // if this should ever happen in reality, whe might want to introduce a more sophisticated recovery
+-                        // for situations where it makes sense
++                        console.error(`Error occurred trying to resolve conflict for service ${service.getFQDN()}. Service is now unannounced and may need to be re-advertised.`);
++                        console.error(error.stack);
++                        if (service.listeners("announce-error").length > 0) {
++                            service.emit("announce-error", error);
++                        }
+                     }
+                 }, true);
+             }

--- a/patches/README.md
+++ b/patches/README.md
@@ -8,3 +8,9 @@ fixes.
 ### [Do not watch fallback map patch when setting up SMP server plugin](./@comapeo+core+7.2.0+001+fix-smp-fallback-map-setup.patch)
 
 By default, core sets up a file watcher for the `fallbackMapPath` option that's provided when instantiating `MapeoManager`. This does not work when packaging the app as an ASAR file (via Electron Forge) because watching a file within the ASAR directory is not possible. Instead, we change the setup so that it does not try to watch the file and instead make the assumption that the file always exists on instantiation, which is generally the case in CoMapeo Desktop (for now).
+
+## @homebridge/ciao
+
+### [Do not exit the process on republishing errors](./@homebridge+ciao+1.3.8+001+handle-republish-errors.patch)
+
+Instead of exiting the process on republishing errors, we emit events that allow graceful error handling to occur in consuming application code. See description in https://github.com/gmaclennan/ciao/pull/1 for more details.

--- a/src/services/core.ts
+++ b/src/services/core.ts
@@ -284,6 +284,22 @@ async function initializePeerDiscovery(manager: MapeoManager) {
 		type: 'comapeo',
 	})
 
+	// NOTE: Gracefully handle announce errors. See relevant patch for @homebridge/ciao
+	service.on(
+		// @ts-expect-error Not worth fixing in patch
+		'announce-error',
+		(reason: unknown) => {
+			log('Announce error occurred', reason)
+			Sentry.captureException(reason)
+
+			// Service is now UNANNOUNCED — safe to call advertise() again
+			service.advertise().catch((error) => {
+				log('Attempting to advertise again failed', error)
+				Sentry.captureException(error)
+			})
+		},
+	)
+
 	let shutdownPromise: Promise<void> | undefined
 
 	async function cleanup() {


### PR DESCRIPTION
Closes #570 

Patches `@homebridge/ciao` to avoid exiting the process when announce errors occur. Instead, we attempt to self-heal and re-advertise. Hoping this helps with some issues we've seen in some devices where discovery doesn't seem to function properly.