### PR TITLE
fix: use lang attributes where appropriate

### DIFF
--- a/src/renderer/src/contexts/intl.tsx
+++ b/src/renderer/src/contexts/intl.tsx
@@ -1,5 +1,6 @@
 import {
 	useDeferredValue,
+	useEffect,
 	useMemo,
 	type ComponentProps,
 	type PropsWithChildren,
@@ -51,6 +52,13 @@ export function IntlProvider({ children }: PropsWithChildren) {
 	const combinedMessages = useMemo(() => {
 		return { ...defaultLanguageMessages, ...localeMessages }
 	}, [defaultLanguageMessages, localeMessages])
+
+	useEffect(
+		function updateDocumentLang() {
+			document.documentElement.lang = persistedLocale
+		},
+		[persistedLocale],
+	)
 
 	return (
 		<ReactIntlProvider

--- a/src/renderer/src/routes/app/settings/_nested/language.tsx
+++ b/src/renderer/src/routes/app/settings/_nested/language.tsx
@@ -11,7 +11,10 @@ import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { defineMessages, useIntl } from 'react-intl'
 import * as v from 'valibot'
 
-import { SupportedLanguageTagSchema } from '../../../../../../shared/intl.ts'
+import {
+	SupportedLanguageTagSchema,
+	type SupportedLanguageTag,
+} from '../../../../../../shared/intl.ts'
 import { DARK_GREY } from '../../../../colors.ts'
 import { DecentDialog } from '../../../../components/decent-dialog.tsx'
 import { ErrorDialogContent } from '../../../../components/error-dialog.tsx'
@@ -87,6 +90,7 @@ function RouteComponent() {
 									control={<Radio />}
 									label={
 										<RadioOptionLabel
+											languageTag={localeState.value}
 											primaryText={t(m.followSystemOptionLabel)}
 										/>
 									}
@@ -107,6 +111,7 @@ function RouteComponent() {
 												// This will change in the future once we have
 												// multiple language variants that we actually support.
 												<RadioOptionLabel
+													languageTag={languageTag}
 													primaryText={
 														baseLanguageInfo
 															? baseLanguageInfo.nativeName
@@ -147,15 +152,20 @@ function RouteComponent() {
 }
 
 function RadioOptionLabel({
+	languageTag,
 	primaryText,
 	secondaryText,
 }: {
+	languageTag: SupportedLanguageTag
 	primaryText: string
 	secondaryText?: string
 }) {
 	return (
 		<Stack direction="column">
-			<Typography sx={{ fontWeight: 500 }}>{primaryText}</Typography>
+			<Typography sx={{ fontWeight: 500 }}>
+				<bdi lang={languageTag}>{primaryText}</bdi>
+			</Typography>
+
 			{secondaryText ? (
 				<Typography color={DARK_GREY}>{secondaryText}</Typography>
 			) : null}

--- a/src/renderer/src/routes/app/settings/_nested/language.tsx
+++ b/src/renderer/src/routes/app/settings/_nested/language.tsx
@@ -23,6 +23,7 @@ import {
 	getLocaleStateQueryOptions,
 	setLocaleMutationOptions,
 } from '../../../../lib/queries/app-settings.ts'
+import { BREADCRUMB_NAV_CURRENT_PAGE_LINK_ID } from './-shared.ts'
 
 export const Route = createFileRoute('/app/settings/_nested/language')({
 	staticData: {
@@ -55,7 +56,7 @@ function RouteComponent() {
 				<Stack direction="column" sx={{ flex: 1, padding: 6 }}>
 					<FormControl>
 						<RadioGroup
-							aria-labelledby="language-selection-label"
+							aria-labelledby={BREADCRUMB_NAV_CURRENT_PAGE_LINK_ID}
 							value={
 								localeState.source !== 'selected' ? 'system' : localeState.value
 							}

--- a/tests-e2e/specs/README.md
+++ b/tests-e2e/specs/README.md
@@ -1,0 +1,12 @@
+# E2E Specs
+
+## Tips
+
+### Avoid using [`Locator.check()`](https://playwright.dev/docs/api/class-locator#locator-check) and [`toBeChecked`](https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-be-checked)
+
+Unfortunately, these have several limitations in our context and do not work well with functionality that only updates the `.checked` JS property.
+
+- https://github.com/microsoft/playwright/issues/39655
+- https://github.com/mui/material-ui/issues/20364
+
+Instead, use [`toHaveJSProperty`](https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-have-js-property).

--- a/tests-e2e/specs/app/project/coordinator-tools.spec.ts
+++ b/tests-e2e/specs/app/project/coordinator-tools.spec.ts
@@ -343,7 +343,6 @@ test.describe('project info', () => {
 					})
 					.fill('Description in back button test')
 
-				// NOTE: Using [`Locator.check()`](https://playwright.dev/docs/api/class-locator#locator-check) is sometimes flaky in CI
 				await main
 					.getByLabel('Project Card Color', { exact: true })
 					.getByRole('checkbox')
@@ -423,7 +422,6 @@ test.describe('project info', () => {
 					})
 					.fill('Description in cancel button test')
 
-				// NOTE: Using [`Locator.check()`](https://playwright.dev/docs/api/class-locator#locator-check) is sometimes flaky in CI
 				await main
 					.getByLabel('Project Card Color', { exact: true })
 					.getByRole('checkbox')
@@ -593,7 +591,6 @@ test.describe('project info', () => {
 					})
 					.fill(updatedProjectParams.projectDescription)
 
-				// NOTE: Using [`Locator.check()`](https://playwright.dev/docs/api/class-locator#locator-check) is sometimes flaky in CI
 				await main
 					.getByLabel('Project Card Color', { exact: true })
 					.getByRole('checkbox', { checked: true })

--- a/tests-e2e/specs/app/settings.spec.ts
+++ b/tests-e2e/specs/app/settings.spec.ts
@@ -681,7 +681,7 @@ test('language', async ({ appInfo, userParams }) => {
 
 			await expect(systemPreferencesOption).toHaveJSProperty('checked', true)
 
-			await expect(page.locator('html')).toHaveAttribute('lang', 'en-US')
+			await expect(page.locator('html')).toHaveAttribute('lang', /^(en$|en-)/)
 
 			await main
 				.getByRole('navigation', { name: 'breadcrumb', exact: true })

--- a/tests-e2e/specs/app/settings.spec.ts
+++ b/tests-e2e/specs/app/settings.spec.ts
@@ -187,10 +187,9 @@ test('index', async ({ appInfo, userParams }) => {
 				exact: true,
 			})
 
-			// NOTE: Using [`Locator.check()`](https://playwright.dev/docs/api/class-locator#locator-check) is sometimes flaky in CI
-			await expect(diagnosticCheckbox).toBeChecked()
+			await expect(diagnosticCheckbox).toHaveJSProperty('checked', true)
 			await diagnosticCheckbox.click()
-			await expect(diagnosticCheckbox).not.toBeChecked()
+			await expect(diagnosticCheckbox).toHaveJSProperty('checked', false)
 		}
 
 		/// App Usage section
@@ -226,12 +225,11 @@ test('index', async ({ appInfo, userParams }) => {
 				exact: true,
 			})
 
-			// NOTE: Using [`Locator.check()`](https://playwright.dev/docs/api/class-locator#locator-check) is sometimes flaky in CI
-			await expect(appUsageCheckbox).not.toBeChecked()
+			await expect(appUsageCheckbox).toHaveJSProperty('checked', false)
 			await appUsageCheckbox.click()
-			await expect(appUsageCheckbox).toBeChecked()
+			await expect(appUsageCheckbox).toHaveJSProperty('checked', true)
 			await appUsageCheckbox.click()
-			await expect(appUsageCheckbox).not.toBeChecked()
+			await expect(appUsageCheckbox).toHaveJSProperty('checked', false)
 		}
 
 		/// About CoMapeo section
@@ -571,9 +569,13 @@ test('language', async ({ appInfo, userParams }) => {
 			)
 		}
 
+		const radioGroup = main.getByRole('radiogroup')
+
 		//// Initial state
 		{
-			const systemPreferencesOption = main.getByRole('radio', {
+			await expect(radioGroup).toHaveAccessibleName('Language')
+
+			const systemPreferencesOption = radioGroup.getByRole('radio', {
 				name: 'Follow system preferences',
 				exact: true,
 				checked: true,
@@ -603,21 +605,24 @@ test('language', async ({ appInfo, userParams }) => {
 				const { nativeName, englishName } =
 					allLanguages[baseTag as keyof typeof allLanguages]!
 
-				const option = main.getByRole('radio', {
+				const option = radioGroup.getByRole('radio', {
 					name: `${nativeName} ${englishName}`,
 				})
 
 				await expect(option).toHaveValue(languageCode)
-				await expect(option).not.toBeChecked()
+				await expect(option).toHaveJSProperty('checked', false)
 			}
 		}
 
 		//// Updating selected value
 		{
-			const portugueseOption = main.getByRole('radio', { name: 'Portuguese' })
-			// NOTE: Using [`Locator.check()`](https://playwright.dev/docs/api/class-locator#locator-check) is sometimes flaky in CI
+			const portugueseOption = radioGroup.getByRole('radio', {
+				name: 'Portuguese',
+			})
 			await portugueseOption.click()
-			await expect(portugueseOption).toBeChecked({ timeout: 2_000 })
+			await expect(portugueseOption).toHaveJSProperty('checked', true)
+
+			await expect(page.locator('html')).toHaveAttribute('lang', 'pt-BR')
 
 			await expect(
 				main
@@ -629,8 +634,10 @@ test('language', async ({ appInfo, userParams }) => {
 					.getByRole('link', { name: 'Idioma', exact: true }),
 			).toBeVisible()
 
+			await expect(radioGroup).toHaveAccessibleName('Idioma')
+
 			await expect(
-				main.getByRole('radio', {
+				radioGroup.getByRole('radio', {
 					name: 'Seguir preferências do sistema',
 					exact: true,
 				}),
@@ -656,17 +663,25 @@ test('language', async ({ appInfo, userParams }) => {
 		//// Returning to language settings page and restoring selection
 		{
 			await expect(
-				main.getByRole('radio', { name: 'Portuguese', checked: true }),
+				radioGroup.getByRole('radio', { name: 'Portuguese', checked: true }),
 			).toBeVisible()
 
-			const systemPreferencesOption = main.getByRole('radio', {
+			let systemPreferencesOption = radioGroup.getByRole('radio', {
 				name: 'Seguir preferências do sistema',
 				exact: true,
 			})
-			// NOTE: Using [`Locator.check()`](https://playwright.dev/docs/api/class-locator#locator-check) is sometimes flaky in CI
-			await expect(systemPreferencesOption).not.toBeChecked()
+
+			await expect(systemPreferencesOption).toHaveJSProperty('checked', false)
 			await systemPreferencesOption.click()
-			await expect(systemPreferencesOption).toBeChecked({ timeout: 2_000 })
+
+			systemPreferencesOption = radioGroup.getByRole('radio', {
+				name: 'Follow system preferences',
+				exact: true,
+			})
+
+			await expect(systemPreferencesOption).toHaveJSProperty('checked', true)
+
+			await expect(page.locator('html')).toHaveAttribute('lang', 'en-US')
 
 			await main
 				.getByRole('navigation', { name: 'breadcrumb', exact: true })
@@ -753,19 +768,21 @@ test('coordinate system', async ({ appInfo, userParams }) => {
 			)
 		}
 
+		const radioGroup = main.getByRole('radiogroup', {
+			name: 'Coordinate System',
+			exact: true,
+		})
+
 		//// Initial state
 		{
-			const radioGroup = main.getByRole('radiogroup')
-			await expect(radioGroup).toHaveAccessibleName('Coordinate System')
-
-			const utmOption = main.getByRole('radio', {
+			const utmOption = radioGroup.getByRole('radio', {
 				name: 'UTM (Universal Transverse Mercator)',
 				exact: true,
 				checked: true,
 			})
 			await expect(utmOption).toHaveValue('utm')
 
-			const uncheckedOptions = main.getByRole('radio', { checked: false })
+			const uncheckedOptions = radioGroup.getByRole('radio', { checked: false })
 			await expect(uncheckedOptions).toHaveCount(2)
 			await expect(uncheckedOptions.first()).toHaveAccessibleName(
 				'DD (Decimal Degrees)',
@@ -779,13 +796,12 @@ test('coordinate system', async ({ appInfo, userParams }) => {
 
 		//// Updating selected value
 		{
-			const ddOption = main.getByRole('radio', {
+			const ddOption = radioGroup.getByRole('radio', {
 				name: 'DD (Decimal Degrees)',
 				exact: true,
 			})
-			// NOTE: Using [`Locator.check()`](https://playwright.dev/docs/api/class-locator#locator-check) is sometimes flaky in CI
 			await ddOption.click()
-			await expect(ddOption).toBeChecked()
+			await expect(ddOption).toHaveJSProperty('checked', true)
 
 			await main
 				.getByRole('navigation', { name: 'breadcrumb', exact: true })
@@ -818,9 +834,8 @@ test('coordinate system', async ({ appInfo, userParams }) => {
 				name: 'UTM (Universal Transverse Mercator)',
 				exact: true,
 			})
-			// NOTE: Using [`Locator.check()`](https://playwright.dev/docs/api/class-locator#locator-check) is sometimes flaky in CI
 			await utmOption.click()
-			await expect(utmOption).toBeChecked()
+			await expect(utmOption).toHaveJSProperty('checked', true)
 
 			await main
 				.getByRole('navigation', { name: 'breadcrumb', exact: true })

--- a/tests-e2e/specs/onboarding.spec.ts
+++ b/tests-e2e/specs/onboarding.spec.ts
@@ -141,9 +141,9 @@ test('data and privacy step', async ({ appInfo }) => {
 			name: 'Share Diagnostic Information',
 			exact: true,
 		})
-		await expect(diagnosticCheckbox).toBeChecked()
+		await expect(diagnosticCheckbox).toHaveJSProperty('checked', true)
 		await diagnosticCheckbox.click()
-		await expect(diagnosticCheckbox).not.toBeChecked()
+		await expect(diagnosticCheckbox).toHaveJSProperty('checked', false)
 
 		await page.getByRole('button', { name: 'Go back', exact: true }).click()
 		await page.getByRole('link', { name: 'Learn More', exact: true }).click()
@@ -153,7 +153,7 @@ test('data and privacy step', async ({ appInfo }) => {
 				name: 'Share Diagnostic Information',
 				exact: true,
 			}),
-		).not.toBeChecked()
+		).toHaveJSProperty('checked', false)
 
 		await page.getByRole('button', { name: 'Go back', exact: true }).click()
 


### PR DESCRIPTION
Closes #577 

Adds the `lang` attribute to the document element and to each displayed language option in the language settings page, based on what's described in https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/lang.

Also fixes a minor accessibility issue on the language settings page related to the radiogroup missing a proper label.