### PR TITLE
fix: recalculate locale to use when preferred system languages change

### DIFF
--- a/src/main/intl-manager.ts
+++ b/src/main/intl-manager.ts
@@ -128,10 +128,21 @@ export class IntlManager extends TypedEmitter<IntlManagerEvents> {
 			log(`Using selected language: ${value}`)
 		}
 
-		this.#intl = this.#createIntl(value)
-		this.#localeSource = source
+		let didChange = false
 
-		this.emit('locale-state', this.localeState)
+		if (this.#intl.locale !== value) {
+			this.#intl = this.#createIntl(value)
+			didChange = true
+		}
+
+		if (this.#localeSource !== source) {
+			this.#localeSource = source
+			didChange = true
+		}
+
+		if (didChange) {
+			this.emit('locale-state', this.localeState)
+		}
 	}
 
 	// Exposing mostly for convenience of usage

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -29,29 +29,16 @@ export function setUpMainIPC({
 	})
 
 	// System
-	ipcMain.handle('system:get:wifiConnections', () => {
+	ipcMain.handle('system:wifiConnections:get', () => {
 		return si.wifiConnections()
 	})
 
-	// Settings (get)
-	ipcMain.handle('settings:get:coordinateFormat', () => {
+	// Settings
+	ipcMain.handle('settings:coordinateFormat:get', () => {
 		return persistedStore.getState().coordinateFormat
 	})
 
-	ipcMain.handle('settings:get:diagnosticsEnabled', () => {
-		return persistedStore.getState().diagnosticsEnabled
-	})
-
-	ipcMain.handle('settings:get:locale', () => {
-		return intlManager.localeState
-	})
-
-	ipcMain.handle('settings:get:appUsageMetrics', () => {
-		return persistedStore.getState().appUsageMetrics
-	})
-
-	// Settings (set)
-	ipcMain.handle('settings:set:coordinateFormat', (_event, value) => {
+	ipcMain.handle('settings:coordinateFormat:set', (_event, value) => {
 		v.assert(
 			v.nonOptional(CurrentStoreStateSchema.entries.coordinateFormat),
 			value,
@@ -59,7 +46,11 @@ export function setUpMainIPC({
 		persistedStore.setState({ coordinateFormat: value })
 	})
 
-	ipcMain.handle('settings:set:diagnosticsEnabled', (_event, value) => {
+	ipcMain.handle('settings:diagnosticsEnabled:get', () => {
+		return persistedStore.getState().diagnosticsEnabled
+	})
+
+	ipcMain.handle('settings:diagnosticsEnabled:set', (_event, value) => {
 		v.assert(
 			v.nonOptional(CurrentStoreStateSchema.entries.diagnosticsEnabled),
 			value,
@@ -67,7 +58,11 @@ export function setUpMainIPC({
 		persistedStore.setState({ diagnosticsEnabled: value })
 	})
 
-	ipcMain.handle('settings:set:locale', (_event, value) => {
+	ipcMain.handle('settings:locale:get', () => {
+		return intlManager.localeState
+	})
+
+	ipcMain.handle('settings:locale:set', (_event, value) => {
 		v.assert(v.nonOptional(CurrentStoreStateSchema.entries.locale), value)
 		persistedStore.setState({ locale: value })
 	})
@@ -76,7 +71,11 @@ export function setUpMainIPC({
 		intlManager.updateLocale(persistedStore.getState().locale)
 	})
 
-	ipcMain.handle('settings:set:appUsageMetrics', (_event, value) => {
+	ipcMain.handle('settings:appUsageMetrics:get', () => {
+		return persistedStore.getState().appUsageMetrics
+	})
+
+	ipcMain.handle('settings:appUsageMetrics:set', (_event, value) => {
 		v.assert(
 			v.object({
 				status: v.union([v.literal('disabled'), v.literal('enabled')]),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -72,6 +72,10 @@ export function setUpMainIPC({
 		persistedStore.setState({ locale: value })
 	})
 
+	ipcMain.on('settings:locale:refresh', () => {
+		intlManager.updateLocale(persistedStore.getState().locale)
+	})
+
 	ipcMain.handle('settings:set:appUsageMetrics', (_event, value) => {
 		v.assert(
 			v.object({

--- a/src/preload/main-window.js
+++ b/src/preload/main-window.js
@@ -57,7 +57,7 @@ const runtimeApi = {
 		return { appVersion, systemVersion, platform: process.platform }
 	},
 	getWifiConnections: async () => {
-		return ipcRenderer.invoke('system:get:wifiConnections')
+		return ipcRenderer.invoke('system:wifiConnections:get')
 	},
 
 	// Shell
@@ -73,35 +73,35 @@ const runtimeApi = {
 
 	// Settings
 	getCoordinateFormat: async () => {
-		return ipcRenderer.invoke('settings:get:coordinateFormat')
+		return ipcRenderer.invoke('settings:coordinateFormat:get')
 	},
 	setCoordinateFormat: async (value) => {
-		return ipcRenderer.invoke('settings:set:coordinateFormat', value)
+		return ipcRenderer.invoke('settings:coordinateFormat:set', value)
 	},
 
 	getDiagnosticsEnabled: async () => {
-		return ipcRenderer.invoke('settings:get:diagnosticsEnabled')
+		return ipcRenderer.invoke('settings:diagnosticsEnabled:get')
 	},
 	setDiagnosticsEnabled: async (value) => {
-		return ipcRenderer.invoke('settings:set:diagnosticsEnabled', value)
+		return ipcRenderer.invoke('settings:diagnosticsEnabled:set', value)
 	},
 
 	getLocaleState: async () => {
-		return ipcRenderer.invoke('settings:get:locale')
+		return ipcRenderer.invoke('settings:locale:get')
 	},
 	setLocale: async (value) => {
-		return ipcRenderer.invoke('settings:set:locale', value)
+		return ipcRenderer.invoke('settings:locale:set', value)
 	},
 	refreshLocale: () => {
 		return ipcRenderer.send('settings:locale:refresh')
 	},
 
 	getAppUsageMetrics: async () => {
-		const result = await ipcRenderer.invoke('settings:get:appUsageMetrics')
+		const result = await ipcRenderer.invoke('settings:appUsageMetrics:get')
 		return result || null
 	},
 	setAppUsageMetrics: async (value) => {
-		return ipcRenderer.invoke('settings:set:appUsageMetrics', value)
+		return ipcRenderer.invoke('settings:appUsageMetrics:set', value)
 	},
 
 	// User

--- a/src/preload/main-window.js
+++ b/src/preload/main-window.js
@@ -92,6 +92,9 @@ const runtimeApi = {
 	setLocale: async (value) => {
 		return ipcRenderer.invoke('settings:set:locale', value)
 	},
+	refreshLocale: () => {
+		return ipcRenderer.send('settings:locale:refresh')
+	},
 
 	getAppUsageMetrics: async () => {
 		const result = await ipcRenderer.invoke('settings:get:appUsageMetrics')

--- a/src/preload/runtime.ts
+++ b/src/preload/runtime.ts
@@ -39,6 +39,7 @@ export type RuntimeApi = {
 
 	getLocaleState: () => Promise<LocaleState>
 	setLocale: (value: Locale) => Promise<void>
+	refreshLocale: () => void
 
 	getAppUsageMetrics: () => Promise<AppUsageMetrics | null>
 	setAppUsageMetrics: (value: {

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -144,6 +144,15 @@ activeProjectIdStore.instance.subscribe((state) => {
 
 localPeersStore.actions.subscribe()
 
+// NOTE: Refresh locale state when user changes language preferences at operating system level
+window.addEventListener('languagechange', () => {
+	window.runtime.refreshLocale()
+
+	queryClient.invalidateQueries({
+		queryKey: getLocaleStateQueryOptions().queryKey,
+	})
+})
+
 export function App() {
 	return (
 		<StrictMode>


### PR DESCRIPTION
Should account for cases where a user updates their preferred operating system language as described by https://developer.mozilla.org/en-US/docs/Web/API/Window/languagechange_event. The recalculation may only have user-facing effects when the in-app language setting is set to use the system preferences.

Unfortunately have not thought too much about how to properly test this. Will document in an issue and leave as an eventual follow-up.