### PR TITLE
chore: compile translations as a separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,6 @@ jobs:
           artifact-ids: ${{ needs.compile_translations.outputs.artifact_id }}
           path: translations/
 
-      - name: Generate translated languages manifest
-        run: node --run intl:generate
-
       - name: Run checks
         run: node --run checks
 
@@ -148,9 +145,6 @@ jobs:
         with:
           artifact-ids: ${{ needs.compile_translations.outputs.artifact_id }}
           path: translations/
-
-      - name: Generate translated languages manifest
-        run: node --run intl:generate
 
       - name: Create packaged app
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   compile_translations:
+    name: Compile translations
     permissions:
       contents: read
     uses: ./.github/workflows/compile-translations.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,22 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
+  compile_translations:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/compile-translations.yml
+
   checks:
+    needs: compile_translations
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Use Node.js
         id: setup-node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -48,13 +59,20 @@ jobs:
             exit 1
           fi
 
-      - name: Build translations
-        run: node --run intl
+      - name: Use built translations artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.compile_translations.outputs.artifact_id }}
+          path: translations/
+
+      - name: Generate translated languages manifest
+        run: node --run intl:generate
 
       - name: Run checks
         run: node --run checks
 
   test:
+    needs: compile_translations
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -62,8 +80,12 @@ jobs:
         os:
           ['ubuntu-latest', 'macos-latest', 'macos-15-intel', 'windows-latest']
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -76,8 +98,11 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Build translations
-        run: node --run intl
+      - name: Use built translations artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.compile_translations.outputs.artifact_id }}
+          path: translations/
 
       - name: Run type checks
         run: node --run types
@@ -86,6 +111,7 @@ jobs:
         run: node --run test
 
   test-e2e:
+    needs: compile_translations
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -98,8 +124,12 @@ jobs:
             { name: 'windows', image: 'windows-latest' },
           ]
     runs-on: ${{ matrix.os.image }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -112,8 +142,14 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Build translations
-        run: node --run intl
+      - name: Use built translations artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.compile_translations.outputs.artifact_id }}
+          path: translations/
+
+      - name: Generate translated languages manifest
+        run: node --run intl:generate
 
       - name: Create packaged app
         env:

--- a/.github/workflows/compile-translations.yml
+++ b/.github/workflows/compile-translations.yml
@@ -1,0 +1,59 @@
+# Summary:
+#
+# Reusable workflow for creating and uploading compiled translations.
+# formatjs tooling no longer supports macOS x64 so we compile the translations as a separate
+# job that gets used by other jobs (https://github.com/digidem/comapeo-desktop/issues/592).
+name: Compile translations
+
+on:
+  workflow_call:
+    inputs:
+      commit_sha:
+        description: 'SHA of commit to use'
+        type: string
+    outputs:
+      artifact_id:
+        description: ID of uploaded artifact containing compiled translations
+        value: ${{ jobs.translations.outputs.artifact_id }}
+
+env:
+  COMMIT_SHA: ${{ inputs.commit_sha || github.sha }}
+
+jobs:
+  translations:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ env.COMMIT_SHA }}
+
+      - name: Use Node.js
+        id: setup-node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Update npm version
+        uses: ./.github/update-npm-version
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Compile translations
+        run: node --run intl:compile
+
+      - name: Upload compiled translations
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: translations-${{ github.sha }}
+          path: translations/
+          overwrite: true
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/compile-translations.yml
+++ b/.github/workflows/compile-translations.yml
@@ -34,7 +34,6 @@ jobs:
           ref: ${{ env.COMMIT_SHA }}
 
       - name: Use Node.js
-        id: setup-node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/compile-translations.yml
+++ b/.github/workflows/compile-translations.yml
@@ -14,13 +14,13 @@ on:
     outputs:
       artifact_id:
         description: ID of uploaded artifact containing compiled translations
-        value: ${{ jobs.translations.outputs.artifact_id }}
+        value: ${{ jobs.compile.outputs.artifact_id }}
 
 env:
   COMMIT_SHA: ${{ inputs.commit_sha || github.sha }}
 
 jobs:
-  translations:
+  compile:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/compile-translations.yml
+++ b/.github/workflows/compile-translations.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Ensure intl outputs are up-to-date
+        run: |
+          node --run intl:extract
+          node --run intl:generate
+          git diff --exit-code
+
       - name: Compile translations
         run: node --run intl:compile
 

--- a/.github/workflows/create-builds.yml
+++ b/.github/workflows/create-builds.yml
@@ -34,6 +34,7 @@ jobs:
   validate_inputs:
     name: Validate inputs
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Validate app_type input
         if: ${{ !(inputs.app_type == 'internal' || inputs.app_type == 'release-candidate' || inputs.app_type == 'production') }}
@@ -41,9 +42,16 @@ jobs:
           echo "app_type input must be one of the following: internal, release-candidate, production"
           exit 1
 
+  compile_translations:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/compile-translations.yml
+    with:
+      commit_sha: ${{ inputs.build_sha || github.sha }}
+
   builds:
     name: Create builds
-    needs: validate_inputs
+    needs: [validate_inputs, compile_translations]
     strategy:
       fail-fast: false
       matrix:
@@ -55,6 +63,8 @@ jobs:
             { name: 'windows', image: 'windows-latest' },
           ]
     runs-on: ${{ matrix.os.image }}
+    permissions:
+      contents: read
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -68,8 +78,8 @@ jobs:
           BUILD_SHA: ${{ env.BUILD_SHA }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ env.BUILD_SHA }}
-          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -82,8 +92,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build translations
-        run: node --run intl
+      - name: Use built translations artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.compile_translations.outputs.artifact_id }}
+          path: translations/
 
         # Roughly follows https://docs.github.com/en/actions/how-tos/deploy/deploy-to-third-party-platforms/sign-xcode-applications
       - name: Set up Apple code signing

--- a/.github/workflows/create-builds.yml
+++ b/.github/workflows/create-builds.yml
@@ -43,6 +43,7 @@ jobs:
           exit 1
 
   compile_translations:
+    name: Compile translations
     permissions:
       contents: read
     uses: ./.github/workflows/compile-translations.yml


### PR DESCRIPTION
Closes #592

Creates a reusable workflow for compiling translations, which is then used by dependent jobs. This avoids platform limitations of the tooling, as the output of the compilation is platform-agnostic.

Also does a lot of cleanup related to improving security for affected workflows.