### PR TITLE
chore: remove unnecessary workaround in compile messages script

### DIFF
--- a/scripts/compile-messages.ts
+++ b/scripts/compile-messages.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, readdirSync, rmSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
-import { join, posix, win32 } from 'node:path'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { compile } from '@formatjs/cli-lib'
 
@@ -21,21 +21,12 @@ mkdirSync(TRANSLATIONS_DIR_RENDERER, { recursive: true })
 
 await Promise.all(
 	languageSourceDirectories.map(async (directory) => {
-		let baseInputPath = join(directory.parentPath, directory.name)
-
-		// NOTE: Workaround due to regression in `@formatjs/cli-lib`
-		// https://github.com/formatjs/formatjs/issues/6603
-		if (process.platform === 'win32') {
-			baseInputPath = new URL(baseInputPath).pathname.replaceAll(
-				win32.sep,
-				posix.sep,
-			)
-		}
+		const baseInputPath = join(directory.parentPath, directory.name)
 
 		const compiled = await compile(
 			[
-				posix.join(baseInputPath, 'primary.json'),
-				posix.join(baseInputPath, 'secondary.json'),
+				join(baseInputPath, 'primary.json'),
+				join(baseInputPath, 'secondary.json'),
 			],
 			{ ast: true, format: 'crowdin' },
 		)


### PR DESCRIPTION
Issue was addressed upstream: https://github.com/formatjs/formatjs/issues/6603

Confirmed that running `node --run intl:compile` locally works on Windows.