### PR TITLE
feat: add Saamaka to supported languages

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -755,6 +755,10 @@
 		"nativeName": "Српски (Serbia)",
 		"englishName": "Serbian (Serbia)"
 	},
+	"srm": {
+		"nativeName": "Saamaka",
+		"englishName": "Saamaka"
+	},
 	"srn": {
 		"nativeName": "Sranan Tongo",
 		"englishName": "Sranan Tongo"


### PR DESCRIPTION
Adds [Saamaka](https://en.wikipedia.org/wiki/Saramaccan_language) to manifest describing supported app languages. It won't show up in the app as an option as right now since there aren't translations, but that will eventually change regardless of the translation status (see #597 ).
