### PR TITLE
fix: fix exchange not working with remote archives

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/exchange/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/exchange/index.tsx
@@ -83,14 +83,20 @@ export const Route = createFileRoute(
 	},
 	onEnter: async ({ context }) => {
 		try {
-			await context.projectApi.$sync.setAutostopDataSyncTimeout(null)
+			await Promise.all([
+				context.projectApi.$sync.setAutostopDataSyncTimeout(null),
+				context.projectApi.$sync.connectServers(),
+			])
 		} catch (err) {
 			captureException(err)
 		}
 	},
 	onLeave: async ({ context }) => {
 		try {
-			await context.projectApi.$sync.setAutostopDataSyncTimeout(30_000)
+			await Promise.all([
+				context.projectApi.$sync.setAutostopDataSyncTimeout(30_000),
+				context.projectApi.$sync.disconnectServers(),
+			])
 		} catch (err) {
 			captureException(err)
 		}
@@ -146,12 +152,19 @@ function RouteComponent() {
 		</Stack>
 	) : (
 		<>
-			<Suspense>
-				<RemoteArchiveIndicator projectId={projectId} />
-			</Suspense>
-
 			{syncState ? (
-				<DisplayedSyncState projectId={projectId} syncState={syncState} />
+				<>
+					<Suspense>
+						<RemoteArchiveIndicator
+							projectId={projectId}
+							remoteDeviceIdsToExchangeWith={Object.keys(
+								syncState.remoteDeviceSyncState,
+							)}
+						/>
+					</Suspense>
+
+					<DisplayedSyncState projectId={projectId} syncState={syncState} />
+				</>
 			) : (
 				<CircularProgress />
 			)}
@@ -318,11 +331,21 @@ function RouteComponent() {
 	)
 }
 
-function RemoteArchiveIndicator({ projectId }: { projectId: string }) {
+function RemoteArchiveIndicator({
+	projectId,
+	remoteDeviceIdsToExchangeWith,
+}: {
+	projectId: string
+	remoteDeviceIdsToExchangeWith: Array<string>
+}) {
 	const { formatMessage: t } = useIntl()
 	const { data: members } = useManyMembers({ projectId, includeLeft: false })
 
-	const activeRemoteArchives = members.filter((m) => memberIsRemoteArchive(m))
+	const activeRemoteArchives = members.filter(
+		(m) =>
+			memberIsRemoteArchive(m) &&
+			remoteDeviceIdsToExchangeWith.includes(m.deviceId),
+	)
 
 	const { online } = useBrowserNetInfo()
 

--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/exchange/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/exchange/index.tsx
@@ -81,25 +81,15 @@ export const Route = createFileRoute(
 			}),
 		])
 	},
-	onEnter: async ({ context }) => {
-		try {
-			await Promise.all([
-				context.projectApi.$sync.setAutostopDataSyncTimeout(null),
-				context.projectApi.$sync.connectServers(),
-			])
-		} catch (err) {
-			captureException(err)
-		}
+	onEnter: ({ context }) => {
+		context.projectApi.$sync
+			.setAutostopDataSyncTimeout(null)
+			.catch(captureException)
 	},
 	onLeave: async ({ context }) => {
-		try {
-			await Promise.all([
-				context.projectApi.$sync.setAutostopDataSyncTimeout(30_000),
-				context.projectApi.$sync.disconnectServers(),
-			])
-		} catch (err) {
-			captureException(err)
-		}
+		context.projectApi.$sync
+			.setAutostopDataSyncTimeout(30_000)
+			.catch(captureException)
 	},
 	component: RouteComponent,
 })

--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/exchange/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/exchange/index.tsx
@@ -142,19 +142,12 @@ function RouteComponent() {
 		</Stack>
 	) : (
 		<>
-			{syncState ? (
-				<>
-					<Suspense>
-						<RemoteArchiveIndicator
-							projectId={projectId}
-							remoteDeviceIdsToExchangeWith={Object.keys(
-								syncState.remoteDeviceSyncState,
-							)}
-						/>
-					</Suspense>
+			<Suspense>
+				<RemoteArchiveIndicator projectId={projectId} />
+			</Suspense>
 
-					<DisplayedSyncState projectId={projectId} syncState={syncState} />
-				</>
+			{syncState ? (
+				<DisplayedSyncState projectId={projectId} syncState={syncState} />
 			) : (
 				<CircularProgress />
 			)}
@@ -321,21 +314,11 @@ function RouteComponent() {
 	)
 }
 
-function RemoteArchiveIndicator({
-	projectId,
-	remoteDeviceIdsToExchangeWith,
-}: {
-	projectId: string
-	remoteDeviceIdsToExchangeWith: Array<string>
-}) {
+function RemoteArchiveIndicator({ projectId }: { projectId: string }) {
 	const { formatMessage: t } = useIntl()
 	const { data: members } = useManyMembers({ projectId, includeLeft: false })
 
-	const activeRemoteArchives = members.filter(
-		(m) =>
-			memberIsRemoteArchive(m) &&
-			remoteDeviceIdsToExchangeWith.includes(m.deviceId),
-	)
+	const activeRemoteArchives = members.filter((m) => memberIsRemoteArchive(m))
 
 	const { online } = useBrowserNetInfo()
 

--- a/src/renderer/src/routes/app/projects/$projectId/route.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/route.tsx
@@ -10,6 +10,7 @@ import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
 import Stack from '@mui/material/Stack'
 import Tooltip from '@mui/material/Tooltip'
+import { captureException } from '@sentry/react'
 import { useIsMutating } from '@tanstack/react-query'
 import {
 	Outlet,
@@ -111,11 +112,17 @@ export const Route = createFileRoute('/app/projects/$projectId')({
 
 		// NOTE: Update the active project ID whenever we navigate to a relevant project-specific page.
 		context.activeProjectIdStore.actions.update(params.projectId)
+
+		// NOTE: Enable connection to remote archives when entering a project-specific route
+		context.projectApi.$sync.connectServers().catch(captureException)
 	},
-	onLeave: () => {
+	onLeave: ({ context }) => {
 		window.localStorage.removeItem(
 			LOCAL_STORAGE_KEYS.USE_ACTIVE_PROJECT_ID_FOR_INITIAL_ROUTE,
 		)
+
+		// NOTE: Disconnect from remote archives when leaving a project-specific route
+		context.projectApi.$sync.disconnectServers().catch(captureException)
 	},
 	component: RouteComponent,
 })


### PR DESCRIPTION
Fixes an issue where exchanging with remote archives isn't enabled and therefore doing an exchange appears to do nothing when it's expected to do something.

Repro steps:

1. On mobile: create a project and add a remote archive
2. On mobile: create an observation. Exchange with remote archive.
3. On mobile: disable exchange.
4. On mobile: add desktop to project.
5. On mobile: close the app (or disable exchange).
6. On desktop: Go to exchange page and start exchange.

After (6), you'll be in a state like this:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/8702f333-d19a-4cf2-8772-0025c76278b2" />

No exchange between desktop and the remote archive occurs, despite there being an observation from (2) that should be available for desktop to obtain.

---

There were a couple of issues:

1. Connecting to remote archives requires a separate call in core to `project.$sync.connectServer()`, which I totally missed 🙃 This PR now updates the implementation such that connection to servers is enabled when initially entering a project-specific page, and disconnected when leaving a project-specific page (or switching to a different project).

2. The UI is a little misleading. Desktop recognizes that some remote archive(s) has been set up, but it doesn't have correct information about whether there's anything to exchange with them. Despite this, the UI displays `Remote Archive connected`, which misleads a user to think that it means it's ready to exchange. ~This PR updates the logic for displaying that copy such that it accounts for whether there's a connected remote archive that is actually able to exchange with desktop.~ EDIT: reverted this since design is working on updating this more holistically.

