### PR TITLE
chore: only upload distribution-related artifacts for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
         id: download
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          pattern: builds-*
           path: assets
           merge-multiple: true
 


### PR DESCRIPTION
Haven't run into this yet but this prevents uploading assets that are not related to distribution when creating a GitHub release.

Context is that we started uploading an artifact for built translations (see #594 ). Prior to this PR, the release workflow downloads all artifacts from the current workflow run - including the translations artifact - and uploads them to the release. Now we only download the artifacts related to distribution which are then uploaded to the release.

See https://github.com/digidem/comapeo-desktop/actions/runs/28233385756 for an example of the artifacts created when running the `create-builds` workflow before this PR. It includes the translations artifact, which is not desirable.