### PR TITLE
fix: update primary action button label in system dialog when downloading data

### DIFF
--- a/messages/en-US/primary.json
+++ b/messages/en-US/primary.json
@@ -323,6 +323,10 @@
     "description": "Title of the download observations page.",
     "message": "Download Observations"
   },
+  "$1.routes.app.projects.$projectId.download.selectDirectoryDialogActionLabel": {
+    "description": "Text used for action button in system dialog for selecting directory to use for download.",
+    "message": "Select"
+  },
   "$1.routes.app.projects.$projectId.download.successPanelDescriptionObservations": {
     "description": "Description text for success panel when downloading observations.",
     "message": "<b>All observations</b><br></br> have been downloaded to your device."

--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/download.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/download.tsx
@@ -200,7 +200,9 @@ function DownloadForm({
 		}: {
 			dataToDownload: DataToDownload
 		}) => {
-			const selectDirectoryResult = await selectDirectory.mutateAsync(undefined)
+			const selectDirectoryResult = await selectDirectory.mutateAsync({
+				actionLabel: t(m.selectDirectoryDialogActionLabel),
+			})
 
 			if (!selectDirectoryResult) {
 				return undefined
@@ -474,6 +476,12 @@ const m = defineMessages({
 		id: '$1.routes.app.projects.$projectId.download.tracksOptionDescription',
 		defaultMessage: 'Text only as a GeoJSON file',
 		description: 'Description of tracks option.',
+	},
+	selectDirectoryDialogActionLabel: {
+		id: '$1.routes.app.projects.$projectId.download.selectDirectoryDialogActionLabel',
+		defaultMessage: 'Select',
+		description:
+			'Text used for action button in system dialog for selecting directory to use for download.',
 	},
 	successPanelTitle: {
 		id: '$1.routes.app.projects.$projectId.download.successPanelTitle',


### PR DESCRIPTION
Updates the text used for the system dialog's primary action button when downloading data. Before, it used to use the system default which - in the case of macOS - was `Open`. Now it uses `Select`, which aligns better with the action taking place.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/89293038-7072-4bd5-b945-2d9cb9239fde" />
