### PR TITLE
feat: allow project panel to be resized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
 				"react-dom": "19.2.7",
 				"react-intl": "10.1.14",
 				"react-map-gl": "8.1.1",
+				"react-resizable-panels": "4.11.2",
 				"semver": "7.8.5",
 				"spin-delay": "2.0.1",
 				"typescript": "6.0.3",
@@ -17877,6 +17878,17 @@
 				"maplibre-gl": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/react-resizable-panels": {
+			"version": "4.11.2",
+			"resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.11.2.tgz",
+			"integrity": "sha512-+kfFbDZ8mygc7g0vxOcDzCVGuwiIUOnILqPoUHo6/uP+Mmyx6HzZU+kj1aOPDlktXuobYbr6BtQekvJwHRX4Eg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/react-transition-group": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
 				"react-dom": "19.2.7",
 				"react-intl": "10.1.14",
 				"react-map-gl": "8.1.1",
-				"react-resizable-panels": "4.11.2",
+				"react-resizable-panels": "4.12.0",
 				"semver": "7.8.5",
 				"spin-delay": "2.0.1",
 				"typescript": "6.0.3",
@@ -17881,9 +17881,9 @@
 			}
 		},
 		"node_modules/react-resizable-panels": {
-			"version": "4.11.2",
-			"resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.11.2.tgz",
-			"integrity": "sha512-+kfFbDZ8mygc7g0vxOcDzCVGuwiIUOnILqPoUHo6/uP+Mmyx6HzZU+kj1aOPDlktXuobYbr6BtQekvJwHRX4Eg==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.0.tgz",
+			"integrity": "sha512-t/Gp57qSCxGQ52ckhz+8lM7dnuymeU95TEzl2U203qEbGkSLHrtm7US2/ANzq/zOlja3CwPTAfCDuh1unv9mfw==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
 				"react-dom": "19.2.7",
 				"react-intl": "10.1.14",
 				"react-map-gl": "8.1.1",
-				"react-resizable-panels": "4.12.0",
+				"react-resizable-panels": "4.12.1",
 				"semver": "7.8.5",
 				"spin-delay": "2.0.1",
 				"typescript": "6.0.3",
@@ -17881,9 +17881,9 @@
 			}
 		},
 		"node_modules/react-resizable-panels": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.0.tgz",
-			"integrity": "sha512-t/Gp57qSCxGQ52ckhz+8lM7dnuymeU95TEzl2U203qEbGkSLHrtm7US2/ANzq/zOlja3CwPTAfCDuh1unv9mfw==",
+			"version": "4.12.1",
+			"resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.1.tgz",
+			"integrity": "sha512-ElE/UpOvMLRWtAqbCgyizHXcbws8RPMyN3cBqmdY17Nxr5f01+DEwzOLqhgcy68GSnjtIUFgKWKl8aIgx5aypQ==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
 		"react-dom": "19.2.7",
 		"react-intl": "10.1.14",
 		"react-map-gl": "8.1.1",
-		"react-resizable-panels": "4.11.2",
+		"react-resizable-panels": "4.12.0",
 		"semver": "7.8.5",
 		"spin-delay": "2.0.1",
 		"typescript": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
 		"react-dom": "19.2.7",
 		"react-intl": "10.1.14",
 		"react-map-gl": "8.1.1",
-		"react-resizable-panels": "4.12.0",
+		"react-resizable-panels": "4.12.1",
 		"semver": "7.8.5",
 		"spin-delay": "2.0.1",
 		"typescript": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
 		"react-dom": "19.2.7",
 		"react-intl": "10.1.14",
 		"react-map-gl": "8.1.1",
+		"react-resizable-panels": "4.11.2",
 		"semver": "7.8.5",
 		"spin-delay": "2.0.1",
 		"typescript": "6.0.3",

--- a/src/renderer/src/routes/app/-components/two-panel-layout.tsx
+++ b/src/renderer/src/routes/app/-components/two-panel-layout.tsx
@@ -27,6 +27,8 @@ export function TwoPanelLayout({
 				minSize={280}
 				maxSize="75%"
 				style={{ boxShadow: BOX_SHADOW, display: 'flex', zIndex: 1 }}
+				// TODO: Consider using this
+				// groupResizeBehavior="preserve-pixel-size"
 			>
 				{start}
 			</Panel>

--- a/src/renderer/src/routes/app/-components/two-panel-layout.tsx
+++ b/src/renderer/src/routes/app/-components/two-panel-layout.tsx
@@ -6,6 +6,7 @@ import {
 	Panel,
 	Separator,
 	useDefaultLayout,
+	usePanelRef,
 } from 'react-resizable-panels'
 
 import { BLACK, BLUE_GREY, LIGHT_GREY, WHITE } from '../../../colors.ts'
@@ -34,6 +35,7 @@ export function TwoPanelLayout({
 	})
 
 	const separatorRef = useRef<HTMLDivElement | null>(null)
+	const startPanelRef = usePanelRef()
 
 	return (
 		<Group
@@ -44,6 +46,7 @@ export function TwoPanelLayout({
 			style={{ position: 'relative' }}
 		>
 			<Panel
+				panelRef={startPanelRef}
 				id="start"
 				onResize={(panelSize) => {
 					if (separatorRef?.current) {
@@ -65,7 +68,28 @@ export function TwoPanelLayout({
 
 			<Separator
 				elementRef={separatorRef}
+				// NOTE: Have to override default arrow key behavior due to absolute positioning
+				onKeyDownCapture={(event) => {
+					if (!startPanelRef.current) {
+						return
+					}
+
+					if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+						return
+					}
+
+					event.stopPropagation()
+
+					const currentSize = startPanelRef.current.getSize()
+
+					const moveByPixels = event.key === 'ArrowRight' ? 50 : -50
+
+					startPanelRef.current.resize(
+						`${currentSize.inPixels + moveByPixels}px`,
+					)
+				}}
 				style={{
+					alignSelf: 'center',
 					backgroundColor: WHITE,
 					borderBottomRightRadius: 4,
 					borderBottomWidth: 1,
@@ -77,8 +101,8 @@ export function TwoPanelLayout({
 					borderTopWidth: 1,
 					display: 'flex',
 					justifyContent: 'center',
+					margin: 'auto',
 					position: 'absolute',
-					top: '50%',
 					zIndex: 1,
 				}}
 			>

--- a/src/renderer/src/routes/app/-components/two-panel-layout.tsx
+++ b/src/renderer/src/routes/app/-components/two-panel-layout.tsx
@@ -1,6 +1,11 @@
 import { type ReactNode } from 'react'
 import { alpha } from '@mui/material/styles'
-import { Group, Panel, useDefaultLayout } from 'react-resizable-panels'
+import {
+	Group,
+	Panel,
+	Separator,
+	useDefaultLayout,
+} from 'react-resizable-panels'
 
 import { BLACK } from '../../../colors.ts'
 
@@ -31,6 +36,8 @@ export function TwoPanelLayout({
 			>
 				{start}
 			</Panel>
+
+			<Separator style={{ width: 1 }} />
 
 			<Panel id="end" style={{ display: 'flex', flex: 1 }}>
 				{end}

--- a/src/renderer/src/routes/app/-components/two-panel-layout.tsx
+++ b/src/renderer/src/routes/app/-components/two-panel-layout.tsx
@@ -27,8 +27,6 @@ export function TwoPanelLayout({
 				minSize={280}
 				maxSize="75%"
 				style={{ boxShadow: BOX_SHADOW, display: 'flex', zIndex: 1 }}
-				// TODO: Consider using this
-				// groupResizeBehavior="preserve-pixel-size"
 			>
 				{start}
 			</Panel>

--- a/src/renderer/src/routes/app/-components/two-panel-layout.tsx
+++ b/src/renderer/src/routes/app/-components/two-panel-layout.tsx
@@ -25,6 +25,7 @@ export function TwoPanelLayout({
 			<Panel
 				id="start"
 				minSize={280}
+				defaultSize="30%"
 				maxSize="75%"
 				style={{ boxShadow: BOX_SHADOW, display: 'flex', zIndex: 1 }}
 			>

--- a/src/renderer/src/routes/app/-components/two-panel-layout.tsx
+++ b/src/renderer/src/routes/app/-components/two-panel-layout.tsx
@@ -1,4 +1,5 @@
-import { type ReactNode } from 'react'
+import { useRef, type ReactNode } from 'react'
+import Box from '@mui/material/Box'
 import { alpha } from '@mui/material/styles'
 import {
 	Group,
@@ -7,9 +8,16 @@ import {
 	useDefaultLayout,
 } from 'react-resizable-panels'
 
-import { BLACK } from '../../../colors.ts'
+import { BLACK, BLUE_GREY, LIGHT_GREY, WHITE } from '../../../colors.ts'
 
-const BOX_SHADOW = `0px 5px 20px 0px ${alpha(BLACK, 0.25)}`
+const BOX_SHADOW = `10px 0px 10px -10px ${alpha(BLACK, 0.1)}`
+
+const PULL_TAB_DOT_STYLE = {
+	backgroundColor: LIGHT_GREY,
+	borderRadius: '50%',
+	height: 8,
+	width: 8,
+} as const
 
 const LOCALSTORAGE_SUFFIX = 'comapeo-project-panels'
 
@@ -25,19 +33,75 @@ export function TwoPanelLayout({
 		storage: localStorage,
 	})
 
+	const separatorRef = useRef<HTMLDivElement | null>(null)
+
 	return (
-		<Group defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
+		<Group
+			defaultLayout={defaultLayout}
+			onLayoutChanged={(layout, meta) => {
+				onLayoutChanged(layout, meta)
+			}}
+			style={{ position: 'relative' }}
+		>
 			<Panel
 				id="start"
+				onResize={(panelSize) => {
+					if (separatorRef?.current) {
+						separatorRef.current.style.left = `${panelSize.inPixels}px`
+					}
+				}}
 				minSize={280}
 				defaultSize="30%"
 				maxSize="75%"
-				style={{ boxShadow: BOX_SHADOW, display: 'flex', zIndex: 1 }}
+				style={{
+					borderRight: `1px solid ${BLUE_GREY}`,
+					boxShadow: BOX_SHADOW,
+					display: 'flex',
+					zIndex: 2,
+				}}
 			>
 				{start}
 			</Panel>
 
-			<Separator style={{ width: 1 }} />
+			<Separator
+				elementRef={separatorRef}
+				style={{
+					backgroundColor: WHITE,
+					borderBottomRightRadius: 4,
+					borderBottomWidth: 1,
+					borderColor: BLUE_GREY,
+					borderLeftWidth: 0,
+					borderRightWidth: 1,
+					borderStyle: 'solid',
+					borderTopRightRadius: 4,
+					borderTopWidth: 1,
+					display: 'flex',
+					justifyContent: 'center',
+					position: 'absolute',
+					top: '50%',
+					zIndex: 1,
+				}}
+			>
+				<Box
+					sx={{
+						columnGap: 1,
+						display: 'grid',
+						gridTemplateColumns: 'repeat(2, 1fr)',
+						gridTemplateRows: 'repeat(3, auto)',
+						paddingBlock: 6,
+						paddingX: 1,
+						placeItems: 'center',
+						rowGap: 1,
+					}}
+				>
+					<Box sx={PULL_TAB_DOT_STYLE} />
+					<Box sx={PULL_TAB_DOT_STYLE} />
+					<Box sx={PULL_TAB_DOT_STYLE} />
+					<Box sx={PULL_TAB_DOT_STYLE} />
+					<Box sx={PULL_TAB_DOT_STYLE} />
+					<Box sx={PULL_TAB_DOT_STYLE} />
+				</Box>
+			</Separator>
 
 			<Panel id="end" style={{ display: 'flex', flex: 1 }}>
 				{end}

--- a/src/renderer/src/routes/app/-components/two-panel-layout.tsx
+++ b/src/renderer/src/routes/app/-components/two-panel-layout.tsx
@@ -1,10 +1,12 @@
-import type { ReactNode } from 'react'
-import Box from '@mui/material/Box'
+import { type ReactNode } from 'react'
 import { alpha } from '@mui/material/styles'
+import { Group, Panel, useDefaultLayout } from 'react-resizable-panels'
 
 import { BLACK } from '../../../colors.ts'
 
 const BOX_SHADOW = `0px 5px 20px 0px ${alpha(BLACK, 0.25)}`
+
+const LOCALSTORAGE_SUFFIX = 'comapeo-project-panels'
 
 export function TwoPanelLayout({
 	start,
@@ -13,23 +15,25 @@ export function TwoPanelLayout({
 	start: ReactNode
 	end: ReactNode
 }) {
+	const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+		id: LOCALSTORAGE_SUFFIX,
+		storage: localStorage,
+	})
+
 	return (
-		<Box sx={{ display: 'flex', flex: 1, overflow: 'auto' }}>
-			<Box
-				sx={{
-					display: 'flex',
-					overflow: 'auto',
-					boxShadow: BOX_SHADOW,
-					minWidth: 250,
-					flex: 1,
-					maxWidth: `min(calc(50%), 450px)`,
-					zIndex: 1,
-				}}
+		<Group defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
+			<Panel
+				id="start"
+				minSize={280}
+				maxSize="75%"
+				style={{ boxShadow: BOX_SHADOW, display: 'flex', zIndex: 1 }}
 			>
 				{start}
-			</Box>
+			</Panel>
 
-			<Box sx={{ display: 'flex', flex: 1, overflow: 'auto' }}>{end}</Box>
-		</Box>
+			<Panel id="end" style={{ display: 'flex', flex: 1 }}>
+				{end}
+			</Panel>
+		</Group>
 	)
 }

--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/-data-list.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/-data-list.tsx
@@ -181,6 +181,7 @@ export function DataList({ projectId }: { projectId: string }) {
 						variant="outlined"
 						to="/app/projects/$projectId/download"
 						params={{ projectId }}
+						sx={{ maxWidth: 400 }}
 					>
 						{t(m.downloadObservations)}
 					</ButtonLink>

--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/observations/$observationDocId/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/observations/$observationDocId/index.tsx
@@ -497,7 +497,10 @@ function ObservationDetailsPanel({
 										padding: 4,
 									}}
 								>
-									<Stack direction="row" sx={{ alignItems: 'center', gap: 4 }}>
+									<Stack
+										direction="row"
+										sx={{ alignItems: 'center', gap: 4, overflow: 'auto' }}
+									>
 										<Box sx={{ position: 'relative' }}>
 											{category ? (
 												<CategoryIconContainer
@@ -546,7 +549,15 @@ function ObservationDetailsPanel({
 											) : null}
 										</Box>
 
-										<Typography variant="h2" sx={{ fontWeight: 500 }}>
+										<Typography
+											variant="h2"
+											sx={{
+												fontWeight: 500,
+												textOverflow: 'ellipsis',
+												whiteSpace: 'nowrap',
+												overflow: 'hidden',
+											}}
+										>
 											{category
 												? category.name
 												: t(m.observationCategoryNameFallback)}

--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/settings/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/settings/index.tsx
@@ -54,7 +54,7 @@ function RouteComponent() {
 					htmlColor={DARKER_ORANGE}
 				/>
 
-				<Typography variant="h1" sx={{ fontWeight: 500 }}>
+				<Typography variant="h1" sx={{ fontWeight: 500, textAlign: 'center' }}>
 					{t(m.navTitle)}
 				</Typography>
 			</Stack>

--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/team/invite/index.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/team/invite/index.tsx
@@ -108,6 +108,7 @@ function RouteComponent() {
 						flex: 1,
 						justifyContent: 'center',
 						gap: 5,
+						overflowWrap: 'break-word',
 						padding: 6,
 					}}
 				>


### PR DESCRIPTION
- Default size: 75% of the space used by the two panels
- Minimum width: 280px
  - Also fixes a couple of layout issues elsewhere as a result of this change (which is smaller than the minimum size for the currently released app)
- Maximum width: 75% of the space used by the two panels
- Can resize by either:
  -  dragging the border between the two panels
  - using the <kbd>Tab</kbd> key to highlight the separator tab and using the left/right arrow keys
- Can reset to the default size by double clicking the separator tab between the two panels
- Layout ratios get persisted and are used for all projects. Can consider scoping it by project if desirable.


---

https://github.com/user-attachments/assets/d9ab904b-7d95-4a92-8113-b2f6cb2d898f