### PR TITLE
fix: fix count calculation in categories filter dropdown

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/-advanced-filters-dialog.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/-advanced-filters-dialog.tsx
@@ -132,7 +132,7 @@ export function AdvancedFiltersDialogContent({
 	const groupedByCategoryCount = useMemo(() => {
 		const { _, ...result } = counting(
 			[...observationsWithCategory, ...tracksWithCategory],
-			(document) => document.category?.docId || '_',
+			({ category }) => category?.docId || '_',
 		)
 
 		return result

--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/-data-list.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/-data-list.tsx
@@ -144,12 +144,12 @@ export function DataList({
 
 	const groupedByCategoryCount = useMemo(() => {
 		const { _, ...result } = counting(
-			[...observations, ...tracks],
-			(document) => document.presetRef?.docId || '_',
+			[...observationsWithCategory, ...tracksWithCategory],
+			({ category }) => category?.docId || '_',
 		)
 
 		return result
-	}, [observations, tracks])
+	}, [observationsWithCategory, tracksWithCategory])
 
 	// NOTE: Accounts for cases where the app is left open for a while
 	// and the user performs an interaction that relies on a more updated date value.


### PR DESCRIPTION
Fixes an issue introduced by #496 where the calculated count for each option in the categories filter could be incorrect. The issue stems from the misalignment of the category that's used when doing the counting. Prior to this change, we were using the doc ID from the document's `presetRef` field directly. However, the count calculation in the advanced filters dialog (which is correct) uses the doc ID of the _resolved_ category (i.e. incorporating tags and accounting for changes in presets). This PR updates the categories filter dropdown to use the same approach for calculating the counts.