### PR TITLE
chore: address install issues in release workflows

### DIFF
--- a/.github/workflows/check-pr-to-release.yml
+++ b/.github/workflows/check-pr-to-release.yml
@@ -76,6 +76,9 @@ jobs:
             package.json
           sparse-checkout-cone-mode: false
 
+      - name: Update npm version
+        uses: ./.github/update-npm-version
+
       - run: npm install --no-save semver
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
             package.json
           sparse-checkout-cone-mode: false
 
+      - name: Update npm version
+        uses: ./.github/update-npm-version
+
       - run: npm install --no-save semver
         shell: bash
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,6 @@
 				"knip": "6.27.0",
 				"maplibre-gl": "5.24.0",
 				"nano-staged": "1.0.2",
-				"network-information-types": "0.1.1",
 				"npm-run-all2": "9.0.2",
 				"patch-package": "8.0.1",
 				"playwright": "1.61.1",
@@ -17201,16 +17200,6 @@
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/network-information-types": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/network-information-types/-/network-information-types-0.1.1.tgz",
-			"integrity": "sha512-mLXNafJYOkiJB6IlF727YWssTRpXitR+tKSLyA5VAdBi3SOvLf5gtizHgxf241YHPWocnAO/fAhVrB/68tPHDw==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"typescript": ">= 3.0.0"
-			}
 		},
 		"node_modules/nice-try": {
 			"version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
 		"knip": "6.27.0",
 		"maplibre-gl": "5.24.0",
 		"nano-staged": "1.0.2",
-		"network-information-types": "0.1.1",
 		"npm-run-all2": "9.0.2",
 		"patch-package": "8.0.1",
 		"playwright": "1.61.1",

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1,13 +1,64 @@
-/// <reference types="network-information-types/dist-types/" />
-
 import type { MessageDescriptor } from 'react-intl'
 
-import { type RuntimeApi } from '../preload/runtime'
+import { type RuntimeApi } from '../preload/runtime.js'
 
 declare global {
 	// Make changes here whenever you expose new things in the preload/ using exposeInMainWorld
 	interface Window {
 		runtime: RuntimeApi
+	}
+
+	// ---
+	// Adjusted vendored version of https://github.com/lacolaco/network-information-types/blob/17d082376d27ee834dc277dfa8e42c9de20440e7/index.d.ts
+	// ---
+
+	// W3C Spec Draft http://wicg.github.io/netinfo/
+	// Edition: Draft Community Group Report 20 February 2019
+
+	// http://wicg.github.io/netinfo/#navigatornetworkinformation-interface
+	interface Navigator {
+		readonly connection?: NetworkInformation
+	}
+	interface WorkerNavigator {
+		readonly connection?: NetworkInformation
+	}
+
+	// http://wicg.github.io/netinfo/#connection-types
+	type ConnectionType =
+		| 'bluetooth'
+		| 'cellular'
+		| 'ethernet'
+		| 'mixed'
+		| 'none'
+		| 'other'
+		| 'unknown'
+		| 'wifi'
+		| 'wimax'
+
+	// http://wicg.github.io/netinfo/#effectiveconnectiontype-enum
+	type EffectiveConnectionType = '2g' | '3g' | '4g' | 'slow-2g'
+
+	// http://wicg.github.io/netinfo/#dom-megabit
+	type Megabit = number
+	// http://wicg.github.io/netinfo/#dom-millisecond
+	type Millisecond = number
+
+	// http://wicg.github.io/netinfo/#networkinformation-interface
+	interface NetworkInformation extends EventTarget {
+		// http://wicg.github.io/netinfo/#type-attribute
+		readonly type?: ConnectionType
+		// http://wicg.github.io/netinfo/#effectivetype-attribute
+		readonly effectiveType?: EffectiveConnectionType
+		// http://wicg.github.io/netinfo/#downlinkmax-attribute
+		readonly downlinkMax?: Megabit
+		// http://wicg.github.io/netinfo/#downlink-attribute
+		readonly downlink?: Megabit
+		// http://wicg.github.io/netinfo/#rtt-attribute
+		readonly rtt?: Millisecond
+		// http://wicg.github.io/netinfo/#savedata-attribute
+		readonly saveData?: boolean
+		// http://wicg.github.io/netinfo/#handling-changes-to-the-underlying-connection
+		onchange?: EventListener
 	}
 }
 


### PR DESCRIPTION
Think the TypeScript introduction in #629 causes the failure seen in https://github.com/digidem/comapeo-desktop/actions/runs/29764026090/job/88425560479. I was running into this locally but was able to bypass it by running `--force` (yeah I know, not safe...). This PR updates a couple of things to potentially mitigate this:

1. Vendor the `network-information-types` module. It's no longer being maintained anyways and there isn't much to vendor. Somehow the TypeScript peer dep of `>= 3.0.0` is contributing to the issue.

2. Make sure that the affected workflows are using an aligned npm version. The `check-pr-to-release` and `release` workflows do an npm install of `semver` using a misaligned npm version to what the project generally uses. Ideally this shouldn't cause issues but just to be safe, I updated the workflows to make sure to install the relevant npm version before doing the steps that make use of the `semver` module.