### PR TITLE
chore: fix install issues in release workflows

### DIFF
--- a/.github/workflows/check-pr-to-release.yml
+++ b/.github/workflows/check-pr-to-release.yml
@@ -73,7 +73,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
+            .github/update-npm-version/action.yml
             package.json
+            package-lock.json
           sparse-checkout-cone-mode: false
 
       - name: Update npm version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,9 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           sparse-checkout: |
+            .github/update-npm-version/action.yml
             package.json
+            package-lock.json
           sparse-checkout-cone-mode: false
 
       - name: Update npm version


### PR DESCRIPTION
Quick follow-up to #630 that:

1. Fixes a dumb mistake related to not checking out the shared action file (see https://github.com/digidem/comapeo-desktop/actions/runs/29773317730/job/88456613770)
2. Most likely fixes the actual issue described in the other PR i.e. making sure to check out the package lock to ensure consistent installs.