### PR TITLE
fix: attempt to use translated category name in outdated filter pill

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/-data-list.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/-data-list.tsx
@@ -542,6 +542,7 @@ export function DataList({
 														<OutdatedFilterPill
 															projectId={projectId}
 															categoryDocId={filterId}
+															lang={lang}
 															onRemove={() => {
 																const updatedFilter = categoriesFilter.filter(
 																	(f) => f !== filterId,
@@ -925,10 +926,12 @@ export function DataList({
 
 function OutdatedFilterPill({
 	categoryDocId,
+	lang,
 	projectId,
 	onRemove,
 }: {
 	categoryDocId: string
+	lang: string
 	projectId: string
 	onRemove: () => void
 }) {
@@ -936,6 +939,7 @@ function OutdatedFilterPill({
 		projectId,
 		docId: categoryDocId,
 		docType: 'preset',
+		lang,
 	})
 
 	return (


### PR DESCRIPTION
Follow-up for #642 . Fixes a potential issue with the displayed name of the outdated filter pill being in English instead of the expected language (assuming the category has a relevant translation).