### PR TITLE
fix: handle errors from map rendering more gracefully

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId/_main-tabs/route.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/_main-tabs/route.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
+import { ErrorBoundary } from '@sentry/react'
 import {
 	Outlet,
 	createFileRoute,
@@ -11,6 +12,7 @@ import { endOfToday } from 'date-fns'
 
 import { TwoPanelLayout } from '../../../-components/two-panel-layout.tsx'
 import { BLACK, LIGHT_GREY } from '../../../../../colors.ts'
+import { GenericRouteErrorComponent } from '../../../../../components/generic-route-error-component.tsx'
 import { COMAPEO_CORE_REACT_ROOT_QUERY_KEY } from '../../../../../lib/comapeo.ts'
 import { MapPanel } from './-map-panel.tsx'
 import {
@@ -95,24 +97,37 @@ function RouteComponent() {
 			start={<Outlet />}
 			end={
 				showMapPanel ? (
-					<Suspense
-						fallback={
-							<Box
-								sx={{
-									display: 'flex',
-									flex: 1,
-									justifyContent: 'center',
-									alignItems: 'center',
-									bgcolor: BLACK,
-									opacity: 0.5,
-								}}
-							>
-								<CircularProgress />
-							</Box>
-						}
+					<ErrorBoundary
+						fallback={({ error, resetError }) => (
+							<GenericRouteErrorComponent
+								error={
+									Error.isError(error)
+										? error
+										: new Error('Failed to render map', { cause: error })
+								}
+								reset={resetError}
+							/>
+						)}
 					>
-						<RouteAwareMapPanel projectId={projectId} />
-					</Suspense>
+						<Suspense
+							fallback={
+								<Box
+									sx={{
+										display: 'flex',
+										flex: 1,
+										justifyContent: 'center',
+										alignItems: 'center',
+										bgcolor: BLACK,
+										opacity: 0.5,
+									}}
+								>
+									<CircularProgress />
+								</Box>
+							}
+						>
+							<RouteAwareMapPanel projectId={projectId} />
+						</Suspense>
+					</ErrorBoundary>
 				) : (
 					<Box sx={{ bgcolor: LIGHT_GREY, display: 'flex', flex: 1 }} />
 				)


### PR DESCRIPTION
Fixes an issue that I've noticed happening more recently in CI ([Sentry event](https://awana-digital.sentry.io/issues/7652533399/)):

> GPUInitializationError: WebGL2 is required to display this map. We are sorry, but it seems that your browser does not support WebGL2, a technology for rendering 3D graphics on the web. Read more on https://wiki.openstreetmap.org/wiki/This_map_requires_WebGL

This is directly related to upgrading maplibre-gl to v6 in #644 , which now only supports WebGL2. From what I can tell, we shouldn't really be having issues with WebGL2 support on the actions runners we use (nor the Chrome version that Electron uses), so not sure why the error is coming up in those scenarios. Regardless, we should be handling map rendering errors more gracefully. In this case, the solution should prevent the e2e tests from failing in CI when the map error occurs, as the UI that's being tested will remain in place.

---

- Before

<img width="600" alt="image" src="https://github.com/user-attachments/assets/57873a7c-f106-44db-97e8-311162a4942c" />

- After

<img width="600" alt="image" src="https://github.com/user-attachments/assets/4bb14b3e-e17a-4efc-abf9-ed5e3bf1f7f2" />