### PR TITLE
fix: fix potential project leave + rejoin issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
 				"zustand": "5.0.14"
 			},
 			"devDependencies": {
-				"@comapeo/core-react": "12.0.2",
+				"@comapeo/core-react": "12.0.3",
 				"@electron-forge/cli": "7.11.2",
 				"@electron-forge/maker-deb": "7.11.2",
 				"@electron-forge/maker-dmg": "7.11.2",
@@ -804,9 +804,9 @@
 			}
 		},
 		"node_modules/@comapeo/core-react": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/@comapeo/core-react/-/core-react-12.0.2.tgz",
-			"integrity": "sha512-QIMW2IAefXjKLN0C+FsIFeOWSky6lVjp/Ufz2ZQ5apsLm769nw7UM5gIPvVcAA8m+aqGGDGs7wiLr0cSNfmTGA==",
+			"version": "12.0.3",
+			"resolved": "https://registry.npmjs.org/@comapeo/core-react/-/core-react-12.0.3.tgz",
+			"integrity": "sha512-nDzjtl9rRGmvGP3DAvCy5/M1B6Hrn08lAXq/xdfcSwC2ocm002ReahK9FcYo+pR3QMzlPzNtN+Px0m+smPzlBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		"zustand": "5.0.14"
 	},
 	"devDependencies": {
-		"@comapeo/core-react": "12.0.2",
+		"@comapeo/core-react": "12.0.3",
 		"@electron-forge/cli": "7.11.2",
 		"@electron-forge/maker-deb": "7.11.2",
 		"@electron-forge/maker-dmg": "7.11.2",


### PR DESCRIPTION
Updates `@comapeo/core-react` to [12.0.3](https://github.com/digidem/comapeo-core-react/releases/tag/v12.0.3) to pull in fixes for issues with project leaving + rejoining.