### PR TITLE
fix: fix issue with viewing project after joining

### DIFF
--- a/src/renderer/src/routes/app/projects/$projectId/route.tsx
+++ b/src/renderer/src/routes/app/projects/$projectId/route.tsx
@@ -77,9 +77,21 @@ export const Route = createFileRoute('/app/projects/$projectId')({
 
 		return { projectApi }
 	},
-	loader: async ({ context, params }) => {
+	loader: async ({ cause, context, params }) => {
 		const { clientApi, projectApi, queryClient } = context
 		const { projectId } = params
+
+		if (cause !== 'preload') {
+			// NOTE: Used by the initial route (`/`) to determine whether we should use
+			// the persisted active project ID for redirecting when opening the app.
+			setItem('use_active_project_id_for_initial_route', true)
+
+			// NOTE: Update the active project ID whenever we navigate to a relevant project-specific page.
+			context.activeProjectIdStore.actions.update(params.projectId)
+
+			// NOTE: Enable connection to remote archives when entering a project-specific route
+			context.projectApi.$sync.connectServers().catch(captureException)
+		}
 
 		await Promise.all([
 			queryClient.ensureQueryData({
@@ -101,17 +113,6 @@ export const Route = createFileRoute('/app/projects/$projectId')({
 				},
 			}),
 		])
-	},
-	onEnter: ({ context, params }) => {
-		// NOTE: Used by the initial route (`/`) to determine whether we should use
-		// the persisted active project ID for redirecting when opening the app.
-		setItem('use_active_project_id_for_initial_route', true)
-
-		// NOTE: Update the active project ID whenever we navigate to a relevant project-specific page.
-		context.activeProjectIdStore.actions.update(params.projectId)
-
-		// NOTE: Enable connection to remote archives when entering a project-specific route
-		context.projectApi.$sync.connectServers().catch(captureException)
 	},
 	onLeave: ({ context }) => {
 		removeItem('use_active_project_id_for_initial_route')


### PR DESCRIPTION
Found this while looking into a separate issue related to navigating joined projects reported by Ximena.

Reproduction steps are as follows:

1. Desktop creates project
2. While Desktop is viewing created project, Mobile invites Desktop to new project.
3. Desktop accepts project invite. Presses `View Project`.

After step 3, _some_ of the UI is updated to reflect viewing the newly joined project. However, there are some parts that are showing stale info related to the project in step 1, such as the project tab near the top.

The key detail here is in step 2, where Desktop is currently viewing some other project while receiving and accepting the new project invite. This issue was caused by a misunderstanding of how [`onEnter`](https://tanstack.com/router/latest/docs/api/router/RouteOptionsType#onenter-property) works, especially in the context of layout routes. We update the active project state in that lifecycle method, which affects UI that isn't nested within a project-specific route (such as the project tab bar). `onEnter` only gets called when going from a non-matching route to a matching route i.e. from a non-project specific page to a project-specific page in this case. It does not handle the case where you navigate from a project-specific page for one project to a project-specific page but for a different project, as is happening in the issue. In order to trigger the relevant side effects for that case, we have to use the `loader` with a guard to check the reason that triggered the `loader` i.e. non-preload reasons like enter or stay. `onStay` was considered, but given that this is a layout route, that method will also be triggered for any navigation to subpages that match this route, which is not desired in this case.

There are probably a couple of other issues that are also fixed, as the side effects were also affecting things like connecting to remote archives and initial navigation behavior when reopening the app.