### PR TITLE
chore: harden create-builds workflow

### DIFF
--- a/.github/workflows/create-builds.yml
+++ b/.github/workflows/create-builds.yml
@@ -140,10 +140,8 @@ jobs:
             exit 1
           fi
 
-          # Set relevant env variables for subsequent job steps
-          echo "APPLE_SIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
-
       - name: Set up Apple notarization
+        id: apple-notarization-setup
         if: ${{ startsWith(matrix.os.name, 'macos') }}
         env:
           KEY: ${{ secrets.APPLE_APP_STORE_CONNECT_AUTH_KEY }}
@@ -155,10 +153,10 @@ jobs:
           # Generate the key file
           echo -n "$KEY" | base64 -d -o "$KEY_PATH"
 
-          # Set relevant env variables for subsequent job steps
-          echo "APPLE_API_KEY_ID=$KEY_ID" >> "$GITHUB_ENV"
-          echo "APPLE_API_KEY_ISSUER=$KEY_ISSUER" >> "$GITHUB_ENV"
-          echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+          # Set outputs for subsequent job steps
+          echo "key_id=$KEY_ID" >> "$GITHUB_OUTPUT"
+          echo "key_issuer=$KEY_ISSUER" >> "$GITHUB_OUTPUT"
+          echo "key_path=$KEY_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Create distributables
         env:
@@ -171,6 +169,11 @@ jobs:
           SENTRY_DSN: ${{ vars.COMAPEO_SENTRY_DSN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          # Apple-specific
+          APPLE_API_KEY_ID: ${{ steps.apple-notarization-setup.outputs.key_id }}
+          APPLE_API_KEY_ISSUER: ${{ steps.apple-notarization-setup.outputs.key_issuer }}
+          APPLE_API_KEY_PATH: ${{ steps.apple-notarization-setup.outputs.key_path }}
+          APPLE_SIGN_IDENTITY: ${{ vars.APPLE_SIGN_IDENTITY }}
         run: node --run forge:make
 
       - name: Upload artifact

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -35,10 +35,6 @@ try {
 
 const {
 	APP_TYPE,
-	APPLE_API_KEY_ID,
-	APPLE_API_KEY_ISSUER,
-	APPLE_API_KEY_PATH,
-	APPLE_SIGN_IDENTITY,
 	ASAR,
 	COMAPEO_DIAGNOSTICS_METRICS_URL,
 	COMAPEO_METRICS_ACCESS_TOKEN,
@@ -60,10 +56,6 @@ const {
 			),
 			'development',
 		),
-		APPLE_API_KEY_ID: v.optional(v.string()),
-		APPLE_API_KEY_ISSUER: v.optional(v.string()),
-		APPLE_API_KEY_PATH: v.optional(v.string()),
-		APPLE_SIGN_IDENTITY: v.optional(v.string()),
 		ASAR: v.optional(
 			v.pipe(
 				v.union(
@@ -476,10 +468,24 @@ function getOsxPackagerConfig(
 			>
 	  >
 	| undefined {
-	const mustSignAndNotarize =
-		appType === 'release-candidate' || appType === 'production'
+	const AppleNotarizeEnv = v.object({
+		APPLE_API_KEY_ID: v.optional(v.pipe(v.string(), v.minLength(1))),
+		APPLE_API_KEY_ISSUER: v.optional(v.pipe(v.string(), v.minLength(1))),
+		APPLE_API_KEY_PATH: v.optional(v.pipe(v.string(), v.minLength(1))),
+		APPLE_SIGN_IDENTITY: v.optional(v.pipe(v.string(), v.minLength(1))),
+	})
+
+	const {
+		APPLE_API_KEY_ID,
+		APPLE_API_KEY_ISSUER,
+		APPLE_API_KEY_PATH,
+		APPLE_SIGN_IDENTITY,
+	} = v.parse(AppleNotarizeEnv, process.env)
 
 	if (!APPLE_SIGN_IDENTITY) {
+		const mustSignAndNotarize =
+			appType === 'release-candidate' || appType === 'production'
+
 		if (mustSignAndNotarize) {
 			throw new Error(
 				'App signing and notarization is required but APPLE_SIGN_IDENTITY env variable is not set.',


### PR DESCRIPTION
Moves away from conditionally setting environment variables in the create-builds workflow, which unnecessarily propagates secrets to subsequent jobs in the workflow. Instead, we set the environment variables using the secrets directly for the relevant job and update the consuming scripts to account for cases where the variables end up being an empty string (due to the relevant outputting job step being skipped)